### PR TITLE
feat: add configurable terminal font family and size

### DIFF
--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -13,6 +13,9 @@ import "./TerminalTab.css";
 // processing many small sequential writes.
 const DATA_BUFFER_FLUSH_MS = 5;
 
+const DEFAULT_FONT_FAMILY = 'Menlo, Monaco, "Courier New", monospace';
+const DEFAULT_FONT_SIZE = 12;
+
 interface TerminalTabProps {
 	sessionId: string;
 	visible: boolean;
@@ -27,10 +30,29 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 	useEffect(() => {
 		if (!containerRef.current) return;
 
+		let cleanup: (() => void) | null = null;
+		let cancelled = false;
+		const container = containerRef.current;
+
+		Promise.all([
+			window.api.getPref("terminalFontFamily").catch(() => null),
+			window.api.getPref("terminalFontSize").catch(() => null),
+		]).then(([rawFamily, rawSize]) => {
+			if (cancelled) return;
+
+			const fontFamily =
+				typeof rawFamily === "string" && rawFamily.trim() !== ""
+					? `${rawFamily.trim()}, ${DEFAULT_FONT_FAMILY}`
+					: DEFAULT_FONT_FAMILY;
+			const fontSize =
+				typeof rawSize === "number" && rawSize >= 6 && rawSize <= 32
+					? rawSize
+					: DEFAULT_FONT_SIZE;
+
 		const term = new Terminal({
 			theme: getTheme(),
-			fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-			fontSize: 12,
+			fontFamily,
+			fontSize,
 			fontWeight: "300",
 			fontWeightBold: "500",
 			cursorBlink: true,
@@ -40,7 +62,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 
 		const fit = new FitAddon();
 		term.loadAddon(fit);
-		term.open(containerRef.current);
+		term.open(container);
 		fitRef.current = fit;
 
 		const unicode11 = new Unicode11Addon();
@@ -158,7 +180,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 				rafId = requestAnimationFrame(() => fit.fit());
 			}
 		});
-		resizeObserver.observe(containerRef.current);
+		resizeObserver.observe(container);
 
 		const mediaQuery = window.matchMedia(
 			"(prefers-color-scheme: dark)",
@@ -168,7 +190,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 		};
 		mediaQuery.addEventListener("change", onThemeChange);
 
-		return () => {
+		cleanup = () => {
 			if (flushTimer !== undefined) {
 				clearTimeout(flushTimer);
 				flushData();
@@ -180,6 +202,12 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			offShellBlur();
 			term.dispose();
 			fitRef.current = null;
+		};
+		});
+
+		return () => {
+			cancelled = true;
+			cleanup?.();
 		};
 	}, [sessionId]);
 

--- a/collab-electron/packages/shared/src/window-api.d.ts
+++ b/collab-electron/packages/shared/src/window-api.d.ts
@@ -111,6 +111,7 @@ export interface CollabApi {
     key: string,
     value: unknown,
   ) => Promise<void>;
+  listMonoFonts: () => Promise<string[]>;
 
   // Theme
   setTheme: (mode: string) => Promise<void>;

--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -536,14 +536,24 @@ ipcMain.handle(
 
 ipcMain.handle("fonts:list-mono", () =>
   new Promise<string[]>((resolve) => {
+    const jxa = `
+ObjC.import("AppKit");
+var families = $.NSFontManager.sharedFontManager.availableFontFamilies;
+var mono = [];
+for (var i = 0; i < families.count; i++) {
+  var name = families.objectAtIndex(i).js;
+  var font = $.NSFont.fontWithNameSize(name, 12);
+  if (font && font.isFixedPitch) mono.push(name);
+}
+mono.join("\\n");
+`.trim();
+
     execFile(
-      "fc-list",
-      ["--format=%{family[0]}\\n", ":spacing=mono"],
+      "osascript",
+      ["-l", "JavaScript", "-e", jxa],
       { encoding: "utf-8", timeout: 5000 },
       (err, stdout) => {
         if (err) {
-          // fc-list requires fontconfig — not available on stock macOS.
-          // Return empty so the UI falls back to "Default (Menlo)".
           resolve([]);
           return;
         }

--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -12,7 +12,7 @@ import {
   webContents as webContentsModule,
   type WebContents,
 } from "electron";
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -532,6 +532,33 @@ ipcMain.handle(
       mainWindow.webContents.send("pref:changed", key, value);
     }
   },
+);
+
+ipcMain.handle("fonts:list-mono", () =>
+  new Promise<string[]>((resolve) => {
+    execFile(
+      "fc-list",
+      ["--format=%{family[0]}\\n", ":spacing=mono"],
+      { encoding: "utf-8", timeout: 5000 },
+      (err, stdout) => {
+        if (err) {
+          // fc-list requires fontconfig — not available on stock macOS.
+          // Return empty so the UI falls back to "Default (Menlo)".
+          resolve([]);
+          return;
+        }
+        const families = [
+          ...new Set(
+            stdout
+              .split("\n")
+              .map((l) => l.trim())
+              .filter((f) => f && !f.startsWith(".")),
+          ),
+        ].sort((a, b) => a.localeCompare(b));
+        resolve(families);
+      },
+    );
+  }),
 );
 
 ipcMain.handle(

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -113,6 +113,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("workspace-pref:get", key),
   setWorkspacePref: (key: string, value: unknown) =>
     ipcRenderer.invoke("workspace-pref:set", key, value),
+  listMonoFonts: () =>
+    ipcRenderer.invoke("fonts:list-mono"),
 
   // Nav + Viewer
   getSelectedFile: () =>

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  CaretDown,
   GearSix,
   Palette,
   Sun,
@@ -17,6 +18,7 @@ interface SettingsApi {
   getAgents: () => Promise<AgentStatus[]>;
   installSkill: (agentId: string) => Promise<{ ok: boolean }>;
   uninstallSkill: (agentId: string) => Promise<{ ok: boolean }>;
+  listMonoFonts: () => Promise<string[]>;
   close: () => void;
 }
 
@@ -170,6 +172,9 @@ function ThemeToggle({
 function AppearancePane() {
   const [theme, setTheme] = useState<ThemeMode>("system");
   const [canvasOpacity, setCanvasOpacity] = useState(0);
+  const [terminalFontFamily, setTerminalFontFamily] = useState("");
+  const [terminalFontSize, setTerminalFontSize] = useState(12);
+  const [monoFonts, setMonoFonts] = useState<string[]>([]);
 
   useEffect(() => {
     api.getPref("theme")
@@ -183,6 +188,21 @@ function AppearancePane() {
         if (typeof v === "number") setCanvasOpacity(v);
       })
       .catch(() => { });
+    api.getPref("terminalFontFamily")
+      .then((v) => {
+        if (typeof v === "string") setTerminalFontFamily(v);
+      })
+      .catch(() => { });
+    api.getPref("terminalFontSize")
+      .then((v) => {
+        if (typeof v === "number") setTerminalFontSize(v);
+      })
+      .catch(() => { });
+    api.listMonoFonts()
+      .then((fonts) => {
+        if (Array.isArray(fonts)) setMonoFonts(fonts);
+      })
+      .catch(() => { });
   }, []);
 
   async function handleThemeChange(mode: ThemeMode) {
@@ -193,6 +213,16 @@ function AppearancePane() {
   async function handleOpacityChange(value: number) {
     setCanvasOpacity(value);
     await api.setPref("canvasOpacity", value);
+  }
+
+  async function handleFontFamilyChange(value: string) {
+    setTerminalFontFamily(value);
+    await api.setPref("terminalFontFamily", value);
+  }
+
+  async function handleFontSizeChange(value: number) {
+    setTerminalFontSize(value);
+    await api.setPref("terminalFontSize", value);
   }
 
   return (
@@ -222,6 +252,47 @@ function AppearancePane() {
         <Slider
           value={canvasOpacity}
           onChange={(v) => { void handleOpacityChange(v); }}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Terminal font</p>
+        <div className="relative">
+        <select
+          value={terminalFontFamily}
+          onChange={(e) => { void handleFontFamilyChange(e.target.value); }}
+          aria-label="Terminal font"
+          className="w-full appearance-none rounded-md border border-border/50 bg-transparent px-2.5 py-1.5 pr-8 text-sm text-foreground focus:outline-none focus:border-foreground/25 cursor-pointer"
+        >
+          <option value="">Default (Menlo)</option>
+          {monoFonts.map((font) => (
+            <option key={font} value={font}>
+              {font}
+            </option>
+          ))}
+        </select>
+        <CaretDown
+          className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
+          weight="bold"
+        />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Changes apply to new terminals.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium">Terminal font size</p>
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {terminalFontSize}px
+          </span>
+        </div>
+        <Slider
+          value={terminalFontSize}
+          min={6}
+          max={32}
+          onChange={(v) => { void handleFontSizeChange(v); }}
         />
       </div>
     </div>


### PR DESCRIPTION
## Problem

The terminal font is hardcoded to `Menlo`, making it impossible to use Nerd Font glyphs — prompts from [Starship](https://starship.rs/), [Powerlevel10k](https://github.com/romkatv/powerlevel10k), or [Oh My Posh](https://ohmyposh.dev/) render broken characters instead of icons.

## Solution

Two new controls under **Settings → Appearance**:

- **Terminal font** — dropdown listing monospace fonts detected on the system via `fc-list`, with `Default (Menlo)` as the fallback
- **Terminal font size** — slider (6–32px) using the same `Slider` component already used for canvas opacity

Persistence reuses the existing `getPref` / `setPref` system. Font enumeration adds one new IPC channel (`fonts:list-mono`) that runs `fc-list` asynchronously to avoid blocking the main process. [`TerminalTab`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/packages/components/src/Terminal/TerminalTab.tsx) reads both preferences before constructing the xterm `Terminal` instance. Changes apply to new terminals.

## Changes

| File | Description |
|------|-------------|
| [`index.ts`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/src/main/index.ts) | Async `fonts:list-mono` IPC handler |
| [`universal.ts`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/src/preload/universal.ts) | Expose `listMonoFonts` on `window.api` |
| [`window-api.d.ts`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/packages/shared/src/window-api.d.ts) | Add `listMonoFonts` type to `CollabApi` |
| [`TerminalTab.tsx`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/packages/components/src/Terminal/TerminalTab.tsx) | Read font prefs before creating xterm instance |
| [`App.tsx`](https://github.com/collaborator-ai/collab-public/blob/main/collab-electron/src/windows/settings/src/App.tsx) | Font select + size slider in `AppearancePane` |

## Limitations

- Font enumeration requires `fc-list` (part of [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/)). On systems without it, the dropdown shows only `Default (Menlo)`.
- No live reload — font changes apply to new terminals, not open sessions.

## Screenshots

<img width="1912" height="1243" alt="image" src="https://github.com/user-attachments/assets/64823506-877c-4b73-87e6-2b7fa7790839" />
<img width="1912" height="1243" alt="image" src="https://github.com/user-attachments/assets/fe8dfd9c-5147-4101-87e8-57c1586b63f9" />

---
Closes [#38](https://github.com/collaborator-ai/collab-public/issues/38)
