### PR TITLE
Increase canvas zoom max from 100% to 200%

### DIFF
--- a/collab-electron/src/windows/shell/src/canvas-viewport.js
+++ b/collab-electron/src/windows/shell/src/canvas-viewport.js
@@ -1,5 +1,5 @@
 const ZOOM_MIN = 0.33;
-const ZOOM_MAX = 1;
+const ZOOM_MAX = 2;
 const ZOOM_RUBBER_BAND_K = 400;
 const CELL = 20;
 const MAJOR = 80;


### PR DESCRIPTION
## Summary
- Raise the maximum zoom level of the canvas (tile layout area) from 100% to 200%
- Makes it easier to read small content inside tiles by zooming in closer
- Existing rubber-band damping and snap-back behavior work unchanged at the new 200% cap

## Changes
- `collab-electron/src/windows/shell/src/canvas-viewport.js`: Change `ZOOM_MAX` from `1` to `2` (single line change)

## Test plan
- [ ] Pinch-zoom on the canvas reaches 200%
- [ ] Zooming beyond 200% rubber-bands back to 200%
- [ ] Zoom indicator shows the correct percentage
- [ ] Tile placement, dragging, and resizing work correctly at higher zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)