### PR TITLE
Feature Request: add Cmd+scroll canvas zoom on macOS

### DIFF
--- a/collab-electron/src/windows/shell/src/canvas-viewport.js
+++ b/collab-electron/src/windows/shell/src/canvas-viewport.js
@@ -4,6 +4,12 @@ const ZOOM_RUBBER_BAND_K = 400;
 const CELL = 20;
 const MAJOR = 80;
 
+const isMac = typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+
+export function shouldZoom(e, mac = isMac) {
+	return e.ctrlKey || (mac && e.metaKey);
+}
+
 function isDark() {
 	return document.documentElement.classList.contains("dark");
 }
@@ -156,7 +162,7 @@ export function createViewport(canvasEl, gridCanvas) {
 	canvasEl.addEventListener("wheel", (e) => {
 		e.preventDefault();
 
-		if (e.ctrlKey) {
+		if (shouldZoom(e)) {
 			const rect = canvasEl.getBoundingClientRect();
 			applyZoom(e.deltaY, e.clientX - rect.left, e.clientY - rect.top);
 		} else {

--- a/collab-electron/src/windows/shell/src/canvas-viewport.test.ts
+++ b/collab-electron/src/windows/shell/src/canvas-viewport.test.ts
@@ -5,6 +5,31 @@
  * After modularization, update imports to use ./canvas-viewport.js.
  */
 import { describe, test, expect } from "bun:test";
+import { shouldZoom } from "./canvas-viewport.js";
+
+// -- shouldZoom modifier key routing --
+
+describe("shouldZoom", () => {
+  test("ctrlKey triggers zoom on any platform", () => {
+    expect(shouldZoom({ ctrlKey: true, metaKey: false }, true)).toBe(true);
+    expect(shouldZoom({ ctrlKey: true, metaKey: false }, false)).toBe(true);
+  });
+
+  test("metaKey triggers zoom only on macOS", () => {
+    expect(shouldZoom({ ctrlKey: false, metaKey: true }, true)).toBe(true);
+    expect(shouldZoom({ ctrlKey: false, metaKey: true }, false)).toBe(false);
+  });
+
+  test("no modifier does not trigger zoom", () => {
+    expect(shouldZoom({ ctrlKey: false, metaKey: false }, true)).toBe(false);
+    expect(shouldZoom({ ctrlKey: false, metaKey: false }, false)).toBe(false);
+  });
+
+  test("both modifiers triggers zoom", () => {
+    expect(shouldZoom({ ctrlKey: true, metaKey: true }, true)).toBe(true);
+    expect(shouldZoom({ ctrlKey: true, metaKey: true }, false)).toBe(true);
+  });
+});
 
 // -- Extracted constants and logic (from renderer.js lines 53-230) --
 


### PR DESCRIPTION
## Summary

- Adds Cmd+scroll as a canvas zoom gesture on macOS, matching the existing Ctrl+scroll / pinch-to-zoom behavior
- Includes a platform guard so `metaKey` only triggers zoom on macOS (avoids unexpected Win+scroll behavior on Windows/Linux)
- Extracts a testable `shouldZoom()` helper for modifier key routing

## Changes

| File | Change |
|------|--------|
| `canvas-viewport.js` | Add `shouldZoom(e, mac)` helper with `isMac` platform detection; replace `e.ctrlKey` with `shouldZoom(e)` in wheel handler |
| `canvas-viewport.test.ts` | Add 4 tests for `shouldZoom` covering ctrlKey, metaKey, no modifier, and both modifiers |

## Test plan

- [x] `bun test canvas-viewport.test.ts` — 16/16 tests pass (12 existing + 4 new)
- [ ] Manual: Cmd+scroll on macOS zooms the canvas
- [ ] Manual: Ctrl+scroll / pinch-to-zoom still works
- [ ] Manual: Plain scroll still pans