### PR TITLE
feat: add terminal copy/paste and tile duplication

### DIFF
--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -16,6 +16,42 @@ const IS_MAC =
 	typeof navigator !== "undefined" &&
 	/Mac|iPhone|iPad|iPod/.test(navigator.platform);
 
+function createKeyEventHandler(
+	sessionId: string,
+	getSelection: () => string | null,
+	copySelection: () => void,
+	pasteClipboard: () => void,
+): (e: KeyboardEvent) => boolean {
+	return (e) => {
+		if (e.key === "Enter" && e.shiftKey) {
+			if (e.type === "keydown") {
+				window.api.ptySendRawKeys(sessionId, "\x1b[13;2u");
+			}
+			return false;
+		}
+		if (e.type !== "keydown") return true;
+
+		const key = e.key.toLowerCase();
+		const isMetaShortcut = IS_MAC && e.metaKey && !e.ctrlKey && !e.altKey;
+		const isCtrlShortcut = !IS_MAC && e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+
+		if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey) {
+			if (key === "c") { copySelection(); return false; }
+			if (key === "v") { pasteClipboard(); return false; }
+		}
+		if (key === "c") {
+			if (isMetaShortcut) { copySelection(); return false; }
+			if (isCtrlShortcut && getSelection()) { copySelection(); return false; }
+		}
+		if (key === "v" && (isMetaShortcut || isCtrlShortcut)) { pasteClipboard(); return false; }
+		if (!IS_MAC && e.shiftKey && key === "insert") { pasteClipboard(); return false; }
+		if (!IS_MAC && e.ctrlKey && !e.metaKey && !e.altKey && key === "insert") { copySelection(); return false; }
+		if ((e.metaKey || e.ctrlKey) && (key === "t" || (key >= "1" && key <= "9"))) return false;
+
+		return true;
+	};
+}
+
 interface TerminalTabProps {
 	sessionId: string;
 	visible: boolean;
@@ -124,72 +160,9 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 		// tmux's input parser which strips modifier info in legacy mode.
 		// Block both keydown AND keypress to prevent xterm from also
 		// sending \r through the normal onData path.
-		term.attachCustomKeyEventHandler((e) => {
-			if (e.key === "Enter" && e.shiftKey) {
-				if (e.type === "keydown") {
-					window.api.ptySendRawKeys(sessionId, "\x1b[13;2u");
-				}
-				return false;
-			}
-			if (e.type === "keydown") {
-				const key = e.key.toLowerCase();
-				const isMetaShortcut =
-					IS_MAC &&
-					e.metaKey &&
-					!e.ctrlKey &&
-					!e.altKey;
-				const isCtrlShortcut =
-					!IS_MAC &&
-					e.ctrlKey &&
-					!e.metaKey &&
-					!e.altKey &&
-					!e.shiftKey;
-				const isCtrlInsert =
-					!IS_MAC &&
-					e.ctrlKey &&
-					!e.metaKey &&
-					!e.altKey &&
-					key === "insert";
-				if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey) {
-					if (key === "c") {
-						void copySelection();
-						return false;
-					}
-					if (key === "v") {
-						void pasteClipboard();
-						return false;
-					}
-				}
-				if (key === "c") {
-					if (isMetaShortcut) {
-						void copySelection();
-						return false;
-					}
-					if (isCtrlShortcut && getSelection()) {
-						void copySelection();
-						return false;
-					}
-				}
-				if (key === "v" && (isMetaShortcut || isCtrlShortcut)) {
-					void pasteClipboard();
-					return false;
-				}
-				if (!IS_MAC && e.shiftKey && key === "insert") {
-					void pasteClipboard();
-					return false;
-				}
-				if (isCtrlInsert) {
-					void copySelection();
-					return false;
-				}
-				if (e.metaKey || e.ctrlKey) {
-					if (key === "t" || (key >= "1" && key <= "9")) {
-						return false;
-					}
-				}
-			}
-			return true;
-		});
+		term.attachCustomKeyEventHandler(
+			createKeyEventHandler(sessionId, getSelection, copySelection, pasteClipboard),
+		);
 
 		const handleCopy = (event: ClipboardEvent) => {
 			const selection = getSelection();

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -12,6 +12,9 @@ import "./TerminalTab.css";
 // call, preventing partial-render artifacts from the renderer
 // processing many small sequential writes.
 const DATA_BUFFER_FLUSH_MS = 5;
+const IS_MAC =
+	typeof navigator !== "undefined" &&
+	/Mac|iPhone|iPad|iPod/.test(navigator.platform);
 
 interface TerminalTabProps {
 	sessionId: string;
@@ -25,7 +28,8 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 	const fitRef = useRef<FitAddon | null>(null);
 
 	useEffect(() => {
-		if (!containerRef.current) return;
+		const container = containerRef.current;
+		if (!container) return;
 
 		const term = new Terminal({
 			theme: getTheme(),
@@ -40,7 +44,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 
 		const fit = new FitAddon();
 		term.loadAddon(fit);
-		term.open(containerRef.current);
+		term.open(container);
 		fitRef.current = fit;
 
 		const unicode11 = new Unicode11Addon();
@@ -89,12 +93,31 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			term.write(scrollbackData);
 		}
 
-		// Shift+Enter: inject a CSI u escape sequence directly into the
-		// tmux pane (via send-keys -l) so TUI apps like Claude Code can
-		// detect the shift modifier. The normal ptyWrite path goes through
-		// tmux's input parser which strips modifier info in legacy mode.
-		// Block both keydown AND keypress to prevent xterm from also
-		// sending \r through the normal onData path.
+		const getSelection = () => {
+			const selection = term.getSelection();
+			return selection.length > 0 ? selection : null;
+		};
+
+		const copySelection = async () => {
+			const selection = getSelection();
+			if (!selection) return;
+			try {
+				window.api.writeClipboardText(selection);
+			} catch (error) {
+				console.error("Failed to copy terminal selection:", error);
+			}
+		};
+
+		const pasteClipboard = async () => {
+			try {
+				const text = window.api.readClipboardText();
+				if (!text) return;
+				term.paste(text);
+			} catch (error) {
+				console.error("Failed to paste into terminal:", error);
+			}
+		};
+
 		term.attachCustomKeyEventHandler((e) => {
 			if (e.key === "Enter" && e.shiftKey) {
 				if (e.type === "keydown") {
@@ -102,13 +125,87 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 				}
 				return false;
 			}
-			if (e.type === "keydown" && e.metaKey) {
-				if (e.key === "t" || (e.key >= "1" && e.key <= "9")) {
+			if (e.type === "keydown") {
+				const key = e.key.toLowerCase();
+				const isMetaShortcut =
+					IS_MAC &&
+					e.metaKey &&
+					!e.ctrlKey &&
+					!e.altKey;
+				const isCtrlShortcut =
+					!IS_MAC &&
+					e.ctrlKey &&
+					!e.metaKey &&
+					!e.altKey &&
+					!e.shiftKey;
+				const isCtrlInsert =
+					!IS_MAC &&
+					e.ctrlKey &&
+					!e.metaKey &&
+					!e.altKey &&
+					key === "insert";
+				if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey) {
+					if (key === "c") {
+						void copySelection();
+						return false;
+					}
+					if (key === "v") {
+						void pasteClipboard();
+						return false;
+					}
+				}
+				if (key === "c") {
+					if (isMetaShortcut) {
+						void copySelection();
+						return false;
+					}
+					if (isCtrlShortcut && getSelection()) {
+						void copySelection();
+						return false;
+					}
+				}
+				if (key === "v" && (isMetaShortcut || isCtrlShortcut)) {
+					void pasteClipboard();
 					return false;
+				}
+				if (!IS_MAC && e.shiftKey && key === "insert") {
+					void pasteClipboard();
+					return false;
+				}
+				if (isCtrlInsert) {
+					void copySelection();
+					return false;
+				}
+				if (e.metaKey || e.ctrlKey) {
+					if (key === "t" || (key >= "1" && key <= "9")) {
+						return false;
+					}
 				}
 			}
 			return true;
 		});
+
+		const handleCopy = (event: ClipboardEvent) => {
+			const selection = getSelection();
+			if (!selection) return;
+			event.preventDefault();
+			event.stopPropagation();
+			event.clipboardData?.setData("text/plain", selection);
+			window.api.writeClipboardText(selection);
+		};
+
+		const handlePaste = (event: ClipboardEvent) => {
+			const text =
+				event.clipboardData?.getData("text/plain") ??
+				window.api.readClipboardText();
+			if (!text) return;
+			event.preventDefault();
+			event.stopPropagation();
+			term.paste(text);
+		};
+
+		container.addEventListener("copy", handleCopy, true);
+		container.addEventListener("paste", handlePaste, true);
 
 		term.onData((data: string) => {
 			window.api.ptyWrite(sessionId, data);
@@ -171,7 +268,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 				rafId = requestAnimationFrame(() => fit.fit());
 			}
 		});
-		resizeObserver.observe(containerRef.current);
+		resizeObserver.observe(container);
 
 		const mediaQuery = window.matchMedia(
 			"(prefers-color-scheme: dark)",
@@ -190,6 +287,8 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			window.removeEventListener("focus", onWindowFocus);
 			mediaQuery.removeEventListener("change", onThemeChange);
 			resizeObserver.disconnect();
+			container.removeEventListener("copy", handleCopy, true);
+			container.removeEventListener("paste", handlePaste, true);
 			window.api.offPtyData(handleData);
 			offShellBlur();
 			term.dispose();

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -98,7 +98,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			return selection.length > 0 ? selection : null;
 		};
 
-		const copySelection = async () => {
+		const copySelection = () => {
 			const selection = getSelection();
 			if (!selection) return;
 			try {
@@ -108,7 +108,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			}
 		};
 
-		const pasteClipboard = async () => {
+		const pasteClipboard = () => {
 			try {
 				const text = window.api.readClipboardText();
 				if (!text) return;

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -52,6 +52,68 @@ function createKeyEventHandler(
 	};
 }
 
+function attachClipboardHandlers(
+	term: Terminal,
+	container: HTMLDivElement,
+	sessionId: string,
+): () => void {
+	const getSelection = () => {
+		const selection = term.getSelection();
+		return selection.length > 0 ? selection : null;
+	};
+
+	const copySelection = () => {
+		const selection = getSelection();
+		if (!selection) return;
+		try {
+			window.api.writeClipboardText(selection);
+		} catch (error) {
+			console.error("Failed to copy terminal selection:", error);
+		}
+	};
+
+	const pasteClipboard = () => {
+		try {
+			const text = window.api.readClipboardText();
+			if (!text) return;
+			term.paste(text);
+		} catch (error) {
+			console.error("Failed to paste into terminal:", error);
+		}
+	};
+
+	term.attachCustomKeyEventHandler(
+		createKeyEventHandler(sessionId, getSelection, copySelection, pasteClipboard),
+	);
+
+	const handleCopy = (event: ClipboardEvent) => {
+		const selection = getSelection();
+		if (!selection) return;
+		event.preventDefault();
+		event.stopPropagation();
+		event.clipboardData?.setData("text/plain", selection);
+		window.api.writeClipboardText(selection);
+	};
+
+	const handlePaste = (event: ClipboardEvent) => {
+		const text =
+			event.clipboardData?.getData("text/plain") ??
+			window.api.readClipboardText();
+		if (!text) return;
+		event.preventDefault();
+		event.stopPropagation();
+		term.paste(text);
+	};
+
+	container.addEventListener("copy", handleCopy, true);
+	container.addEventListener("paste", handlePaste, true);
+
+	return () => {
+		container.removeEventListener("copy", handleCopy, true);
+		container.removeEventListener("paste", handlePaste, true);
+	};
+}
+
 interface TerminalTabProps {
 	sessionId: string;
 	visible: boolean;
@@ -129,62 +191,13 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			term.write(scrollbackData);
 		}
 
-		const getSelection = () => {
-			const selection = term.getSelection();
-			return selection.length > 0 ? selection : null;
-		};
-
-		const copySelection = () => {
-			const selection = getSelection();
-			if (!selection) return;
-			try {
-				window.api.writeClipboardText(selection);
-			} catch (error) {
-				console.error("Failed to copy terminal selection:", error);
-			}
-		};
-
-		const pasteClipboard = () => {
-			try {
-				const text = window.api.readClipboardText();
-				if (!text) return;
-				term.paste(text);
-			} catch (error) {
-				console.error("Failed to paste into terminal:", error);
-			}
-		};
-
 		// Shift+Enter: inject a CSI u escape sequence directly into the
 		// tmux pane (via send-keys -l) so TUI apps like Claude Code can
 		// detect the shift modifier. The normal ptyWrite path goes through
 		// tmux's input parser which strips modifier info in legacy mode.
 		// Block both keydown AND keypress to prevent xterm from also
 		// sending \r through the normal onData path.
-		term.attachCustomKeyEventHandler(
-			createKeyEventHandler(sessionId, getSelection, copySelection, pasteClipboard),
-		);
-
-		const handleCopy = (event: ClipboardEvent) => {
-			const selection = getSelection();
-			if (!selection) return;
-			event.preventDefault();
-			event.stopPropagation();
-			event.clipboardData?.setData("text/plain", selection);
-			window.api.writeClipboardText(selection);
-		};
-
-		const handlePaste = (event: ClipboardEvent) => {
-			const text =
-				event.clipboardData?.getData("text/plain") ??
-				window.api.readClipboardText();
-			if (!text) return;
-			event.preventDefault();
-			event.stopPropagation();
-			term.paste(text);
-		};
-
-		container.addEventListener("copy", handleCopy, true);
-		container.addEventListener("paste", handlePaste, true);
+		const cleanupClipboard = attachClipboardHandlers(term, container, sessionId);
 
 		term.onData((data: string) => {
 			window.api.ptyWrite(sessionId, data);
@@ -266,8 +279,7 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			window.removeEventListener("focus", onWindowFocus);
 			mediaQuery.removeEventListener("change", onThemeChange);
 			resizeObserver.disconnect();
-			container.removeEventListener("copy", handleCopy, true);
-			container.removeEventListener("paste", handlePaste, true);
+			cleanupClipboard();
 			window.api.offPtyData(handleData);
 			offShellBlur();
 			term.dispose();

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -118,6 +118,12 @@ function TerminalTab({ sessionId, visible, restored, scrollbackData }: TerminalT
 			}
 		};
 
+		// Shift+Enter: inject a CSI u escape sequence directly into the
+		// tmux pane (via send-keys -l) so TUI apps like Claude Code can
+		// detect the shift modifier. The normal ptyWrite path goes through
+		// tmux's input parser which strips modifier info in legacy mode.
+		// Block both keydown AND keypress to prevent xterm from also
+		// sending \r through the normal onData path.
 		term.attachCustomKeyEventHandler((e) => {
 			if (e.key === "Enter" && e.shiftKey) {
 				if (e.type === "keydown") {

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -46,7 +46,7 @@ function createKeyEventHandler(
 		if (key === "v" && (isMetaShortcut || isCtrlShortcut)) { pasteClipboard(); return false; }
 		if (!IS_MAC && e.shiftKey && key === "insert") { pasteClipboard(); return false; }
 		if (!IS_MAC && e.ctrlKey && !e.metaKey && !e.altKey && key === "insert") { copySelection(); return false; }
-		if ((e.metaKey || e.ctrlKey) && (key === "t" || (key >= "1" && key <= "9"))) return false;
+		if (isMetaShortcut && (key === "t" || (key >= "1" && key <= "9"))) return false;
 
 		return true;
 	};

--- a/collab-electron/packages/shared/src/window-api.d.ts
+++ b/collab-electron/packages/shared/src/window-api.d.ts
@@ -114,6 +114,8 @@ export interface CollabApi {
 
   // Theme
   setTheme: (mode: string) => Promise<void>;
+  readClipboardText: () => string;
+  writeClipboardText: (text: string) => void;
 
   // File selection
   getSelectedFile: () => Promise<string | null>;

--- a/collab-electron/packages/shared/src/window-api.d.ts
+++ b/collab-electron/packages/shared/src/window-api.d.ts
@@ -223,6 +223,9 @@ export interface CollabApi {
     cols: number,
     rows: number,
   ) => Promise<PtySession & { scrollback: string }>;
+  ptyGetCwd: (
+    sessionId: string,
+  ) => Promise<string | null>;
   ptyDiscover: () => Promise<
     Array<{
       sessionId: string;

--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -597,6 +597,12 @@ ipcMain.handle(
   (_event, sessionId: string) => pty.getForegroundProcess(sessionId),
 );
 
+ipcMain.handle(
+  "pty:cwd",
+  (_event, { sessionId }: { sessionId: string }) =>
+    pty.getCurrentDirectory(sessionId),
+);
+
 let settingsOpen = false;
 
 function setSettingsOpen(open: boolean): void {

--- a/collab-electron/src/main/pty.ts
+++ b/collab-electron/src/main/pty.ts
@@ -401,6 +401,20 @@ export function getForegroundProcess(
   }
 }
 
+export function getCurrentDirectory(
+  sessionId: string,
+): string | null {
+  const name = tmuxSessionName(sessionId);
+  try {
+    return tmuxExec(
+      "display-message", "-t", name,
+      "-p", "#{pane_current_path}",
+    );
+  } catch {
+    return null;
+  }
+}
+
 const lastForeground = new Map<string, string>();
 const statusTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const STATUS_DEBOUNCE_MS = 500;

--- a/collab-electron/src/preload/shell.ts
+++ b/collab-electron/src/preload/shell.ts
@@ -149,6 +149,8 @@ contextBridge.exposeInMainWorld("shellApi", {
   canvasLoadState: () => ipcRenderer.invoke("canvas:load-state"),
   canvasSaveState: (state: unknown) =>
     ipcRenderer.invoke("canvas:save-state", state),
+  ptyGetCwd: (sessionId: string) =>
+    ipcRenderer.invoke("pty:cwd", { sessionId }),
 
   getDragPaths: () => ipcRenderer.invoke("drag:get-paths"),
 

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -1,4 +1,5 @@
 import {
+  clipboard,
   contextBridge,
   ipcRenderer,
   type IpcRendererEvent,
@@ -284,6 +285,8 @@ contextBridge.exposeInMainWorld("api", {
   // Theme
   setTheme: (mode: string) =>
     ipcRenderer.invoke("theme:set", mode),
+  readClipboardText: () => clipboard.readText(),
+  writeClipboardText: (text: string) => clipboard.writeText(text),
 
   // Settings
   openFolder: () =>

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -238,6 +238,8 @@ contextBridge.exposeInMainWorld("api", {
       "pty:reconnect",
       { sessionId, cols, rows },
     ),
+  ptyGetCwd: (sessionId: string) =>
+    ipcRenderer.invoke("pty:cwd", { sessionId }),
   ptyDiscover: () =>
     ipcRenderer.invoke("pty:discover"),
   ptyCleanDetached: (activeSessionIds: string[]) =>

--- a/collab-electron/src/windows/shell/src/canvas-state.js
+++ b/collab-electron/src/windows/shell/src/canvas-state.js
@@ -69,7 +69,7 @@ const IMAGE_EXTENSIONS = new Set([
 	".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp",
 ]);
 
-const GRID_CELL = 20;
+export const GRID_CELL = 20;
 
 /** Snap tile position and size to the minor grid. */
 export function snapToGrid(tile) {

--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -1,6 +1,6 @@
 import "./shell.css";
 import {
-	tiles, getTile, defaultSize, inferTileType,
+	tiles, getTile, defaultSize, inferTileType, GRID_CELL,
 	selectTile, clearSelection, getSelectedTiles,
 } from "./canvas-state.js";
 import { attachMarquee } from "./tile-interactions.js";
@@ -109,6 +109,8 @@ async function init() {
 	let spaceHeld = false;
 	let isPanning = false;
 	let suppressCanvasDblClickUntil = 0;
+	let copiedTerminalTiles = [];
+	let pendingTerminalTileCopy = null;
 
 	// -- Drag-and-drop handler (shared with webviews) --
 
@@ -261,6 +263,17 @@ async function init() {
 		},
 		onTileDblClick(tile) {
 			edgeIndicators.panToTile(tile);
+		},
+		onCanvasFrameFocus: () => {
+			canvasEl.focus();
+			noteSurfaceFocus("canvas");
+		},
+		onCanvasTileContextMenu: async (tileId) => {
+			const items = terminalTileClipboard.getMenuItems(tileId);
+			if (items.length === 0) return;
+
+			const selected = await window.shellApi.showContextMenu(items);
+			await terminalTileClipboard.handleMenuAction(selected, tileId);
 		},
 	});
 
@@ -570,9 +583,212 @@ async function init() {
 		getAllWebviews,
 	});
 
+	function isEditableTarget(target) {
+		if (!(target instanceof HTMLElement)) return false;
+		if (target instanceof HTMLInputElement) return true;
+		if (target instanceof HTMLTextAreaElement) return true;
+		if (target instanceof HTMLSelectElement) return true;
+		return !!target.closest("[contenteditable]:not([contenteditable='false'])");
+	}
+
+	function createTerminalTileClipboard() {
+		function getSourceTiles(sourceTileId = null) {
+			const selected = getSelectedTiles();
+			if (sourceTileId) {
+				const sourceTile = getTile(sourceTileId);
+				if (sourceTile?.type !== "term") return [];
+				if (
+					selected.length > 0 &&
+					selected.every((tile) => tile.type === "term") &&
+					selected.some((tile) => tile.id === sourceTileId)
+				) {
+					return selected;
+				}
+				return [sourceTile];
+			}
+
+			if (selected.length > 0) {
+				return selected.every((tile) => tile.type === "term")
+					? selected
+					: [];
+			}
+
+			return [];
+		}
+
+		function formatActionLabel(action, count) {
+			return count === 1
+				? `${action} terminal tile`
+				: `${action} ${count} terminal tiles`;
+		}
+
+		function createBlueprint(tile) {
+			return {
+				x: tile.x,
+				y: tile.y,
+				width: tile.width,
+				height: tile.height,
+				cwd: tile.cwd,
+			};
+		}
+
+		function copyBlueprints(tilesToCopy) {
+			copiedTerminalTiles = tilesToCopy.map(createBlueprint);
+		}
+
+		async function refreshSourceTiles(sourceTiles) {
+			let changed = false;
+			await Promise.all(sourceTiles.map(async (tile) => {
+				if (tile.type !== "term" || !tile.ptySessionId) return;
+				try {
+					const cwd = await window.shellApi.ptyGetCwd(tile.ptySessionId);
+					if (cwd && cwd !== tile.cwd) {
+						tile.cwd = cwd;
+						changed = true;
+					}
+				} catch {
+					// Fall back to the last known tile cwd if the PTY is unavailable.
+				}
+			}));
+			if (changed) {
+				tileManager.saveCanvasDebounced();
+			}
+		}
+
+		function finalizePaste(duplicatedTiles) {
+			tileManager.blurCanvasTileGuest();
+			tileManager.setFocusedTileId(null);
+			tileManager.clearTileFocusRing();
+			tileManager.syncSelectionVisuals();
+			tileManager.saveCanvasImmediate();
+			canvasEl.focus();
+			noteSurfaceFocus("canvas");
+			copyBlueprints(duplicatedTiles);
+		}
+
+		async function copy(sourceTileId = null) {
+			if (isEditableTarget(document.activeElement)) return false;
+			const sourceTiles = getSourceTiles(sourceTileId);
+			if (sourceTiles.length === 0) return false;
+			await refreshSourceTiles(sourceTiles);
+			copyBlueprints(sourceTiles);
+			return true;
+		}
+
+		function runCopy(sourceTileId = null) {
+			const copyPromise = copy(sourceTileId);
+			pendingTerminalTileCopy = copyPromise.finally(() => {
+				if (pendingTerminalTileCopy === copyPromise) {
+					pendingTerminalTileCopy = null;
+				}
+			});
+			return copyPromise;
+		}
+
+		function pasteNow() {
+			if (copiedTerminalTiles.length === 0) return false;
+
+			const duplicatedTiles = [];
+			clearSelection();
+
+			for (const blueprint of copiedTerminalTiles) {
+				const tile = tileManager.createCanvasTile(
+					"term",
+					blueprint.x + blueprint.width + GRID_CELL,
+					blueprint.y,
+					{
+						width: blueprint.width,
+						height: blueprint.height,
+						cwd: blueprint.cwd,
+					},
+				);
+				duplicatedTiles.push(tile);
+				tileManager.spawnTerminalWebview(tile, false);
+				selectTile(tile.id);
+			}
+
+			finalizePaste(duplicatedTiles);
+			return true;
+		}
+
+		async function paste() {
+			if (pendingTerminalTileCopy) {
+				const copied = await pendingTerminalTileCopy;
+				if (!copied) return false;
+			}
+			if (isEditableTarget(document.activeElement)) return false;
+			return pasteNow();
+		}
+
+		return {
+			getMenuItems(tileId) {
+				const sourceTiles = getSourceTiles(tileId);
+				const items = [];
+				if (sourceTiles.length > 0) {
+					items.push({
+						id: "copy-terminal-tiles",
+						label: formatActionLabel("Copy", sourceTiles.length),
+					});
+					items.push({
+						id: "duplicate-terminal-tiles",
+						label: formatActionLabel("Duplicate", sourceTiles.length),
+					});
+				}
+				if (copiedTerminalTiles.length > 0) {
+					items.push({
+						id: "paste-terminal-tiles",
+						label: formatActionLabel("Paste", copiedTerminalTiles.length),
+					});
+				}
+				return items;
+			},
+			async handleMenuAction(action, tileId) {
+				if (action === "copy-terminal-tiles") {
+					await runCopy(tileId);
+					return;
+				}
+				if (action === "duplicate-terminal-tiles") {
+					if (await runCopy(tileId)) {
+						pasteNow();
+					}
+					return;
+				}
+				if (action === "paste-terminal-tiles") {
+					await paste();
+				}
+			},
+			runCopy,
+			paste,
+		};
+	}
+
+	const terminalTileClipboard = createTerminalTileClipboard();
+
 	// -- Selection keyboard handlers --
 
 	window.addEventListener("keydown", (e) => {
+		const hasCommandModifier = e.metaKey || e.ctrlKey;
+		if (
+			hasCommandModifier &&
+			!e.shiftKey &&
+			!e.altKey &&
+			!isEditableTarget(e.target)
+		) {
+			const key = e.key.toLowerCase();
+			if (key === "c") {
+				e.preventDefault();
+				e.stopPropagation();
+				void terminalTileClipboard.runCopy();
+				return;
+			}
+			if (key === "v") {
+				e.preventDefault();
+				e.stopPropagation();
+				void terminalTileClipboard.paste();
+				return;
+			}
+		}
+
 		if (e.key === "Escape" && getSelectedTiles().length > 0) {
 			clearSelection();
 			tileManager.syncSelectionVisuals();
@@ -581,8 +797,7 @@ async function init() {
 
 		if (
 			(e.key === "Backspace" || e.key === "Delete") &&
-			(activeSurface === "canvas" ||
-				activeSurface === "canvas-tile")
+			!isEditableTarget(e.target)
 		) {
 			const selected = getSelectedTiles();
 			if (selected.length === 0) return;
@@ -603,7 +818,7 @@ async function init() {
 				tileManager.syncSelectionVisuals();
 			});
 		}
-	});
+	}, true);
 
 	// -- Shift scroll passthrough --
 

--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -690,11 +690,20 @@ async function init() {
 
 			const duplicatedTiles = [];
 			clearSelection();
+			const minX = Math.min(
+				...copiedTerminalTiles.map((blueprint) => blueprint.x),
+			);
+			const maxRight = Math.max(
+				...copiedTerminalTiles.map(
+					(blueprint) => blueprint.x + blueprint.width,
+				),
+			);
+			const offsetX = maxRight - minX + GRID_CELL;
 
 			for (const blueprint of copiedTerminalTiles) {
 				const tile = tileManager.createCanvasTile(
 					"term",
-					blueprint.x + blueprint.width + GRID_CELL,
+					blueprint.x + offsetX,
 					blueprint.y,
 					{
 						width: blueprint.width,

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -23,6 +23,8 @@ export function createTileManager({
 	onTerminalTileClosed,
 	onTileFocused,
 	onTileDblClick,
+	onCanvasFrameFocus,
+	onCanvasTileContextMenu,
 }) {
 	/** @type {Map<string, {container: HTMLElement, contentArea: HTMLElement, titleText: HTMLElement, webview?: HTMLElement}>} */
 	const tileDOMs = new Map();
@@ -57,6 +59,7 @@ export function createTileManager({
 				filePath: t.filePath,
 				folderPath: t.folderPath,
 				workspacePath: t.workspacePath,
+				cwd: t.cwd,
 				ptySessionId: t.ptySessionId,
 				url: t.url,
 				zIndex: t.zIndex,
@@ -213,6 +216,14 @@ export function createTileManager({
 				saveCanvasDebounced();
 				if (onTerminalSessionCreated) {
 					onTerminalSessionCreated(tile);
+				}
+				return;
+			}
+			if (event.channel === "pty-cwd") {
+				const cwd = event.args[0];
+				if (cwd && cwd !== tile.cwd) {
+					tile.cwd = cwd;
+					saveCanvasDebounced();
 				}
 			}
 		});
@@ -425,9 +436,34 @@ export function createTileManager({
 					syncSelectionVisuals();
 					return;
 				}
+				const t = getTile(id);
+				if (t) {
+					bringToFront(t);
+					repositionAllTiles();
+				}
 				clearSelection();
+				selectTile(id);
 				syncSelectionVisuals();
-				focusCanvasTile(id, e);
+				blurCanvasTileGuest();
+				clearTileFocusRing();
+				focusedTileId = null;
+				onCanvasFrameFocus();
+			},
+			onContextMenu: (id, e) => {
+				if (e) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
+				if (!isSelected(id)) {
+					clearSelection();
+					selectTile(id);
+					syncSelectionVisuals();
+				}
+				blurCanvasTileGuest();
+				clearTileFocusRing();
+				focusedTileId = null;
+				onCanvasFrameFocus();
+				onCanvasTileContextMenu?.(id);
 			},
 			onOpenInViewer: (id) => {
 				const t = getTile(id);
@@ -617,6 +653,7 @@ export function createTileManager({
 						width: saved.width,
 						height: saved.height,
 						zIndex: saved.zIndex,
+						cwd: saved.cwd,
 						ptySessionId: saved.ptySessionId,
 					},
 				);

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -124,6 +124,13 @@ export function createTileManager({
 		try { dom.webview.blur(); } catch { /* noop */ }
 	}
 
+	function resetFocusToCanvas() {
+		blurCanvasTileGuest();
+		clearTileFocusRing();
+		focusedTileId = null;
+		onCanvasFrameFocus();
+	}
+
 	function forwardClickToWebview(webview, mouseEvent) {
 		const rect = webview.getBoundingClientRect();
 		if (rect.width === 0 || rect.height === 0) return;
@@ -444,10 +451,7 @@ export function createTileManager({
 				clearSelection();
 				selectTile(id);
 				syncSelectionVisuals();
-				blurCanvasTileGuest();
-				clearTileFocusRing();
-				focusedTileId = null;
-				onCanvasFrameFocus();
+				resetFocusToCanvas();
 			},
 			onContextMenu: (id, e) => {
 				if (e) {
@@ -459,10 +463,7 @@ export function createTileManager({
 					selectTile(id);
 					syncSelectionVisuals();
 				}
-				blurCanvasTileGuest();
-				clearTileFocusRing();
-				focusedTileId = null;
-				onCanvasFrameFocus();
+				resetFocusToCanvas();
 				onCanvasTileContextMenu?.(id);
 			},
 			onOpenInViewer: (id) => {

--- a/collab-electron/src/windows/shell/src/tile-renderer.js
+++ b/collab-electron/src/windows/shell/src/tile-renderer.js
@@ -4,6 +4,7 @@
  * @param {object} callbacks
  * @param {(id: string) => void} callbacks.onClose
  * @param {(id: string, e?: MouseEvent) => void} callbacks.onFocus
+ * @param {((id: string, e: MouseEvent) => void)|null} [callbacks.onContextMenu]
  * @param {((id: string) => void)|null} [callbacks.onOpenInViewer]
  * @param {((id: string, url: string) => void)|null} [callbacks.onNavigate]
  */
@@ -12,6 +13,10 @@ export function createTileDOM(tile, callbacks) {
   container.className = "canvas-tile";
   container.dataset.tileId = tile.id;
   container.dataset.tileType = tile.type;
+  container.addEventListener("contextmenu", (e) => {
+    if (!callbacks.onContextMenu) return;
+    callbacks.onContextMenu(tile.id, e);
+  });
 
   const titleBar = document.createElement("div");
   titleBar.className = "tile-title-bar";


### PR DESCRIPTION
## Summary
- Add clipboard support in terminal tiles (Cmd+C/V on macOS, Ctrl+C/V and Ctrl+Shift+C/V on other platforms, plus Ctrl+Insert/Shift+Insert)
- Add terminal tile duplication via Cmd+C/V on the canvas (copies selected terminal tiles as blueprints, pastes as new tiles with the same cwd and dimensions)
- Add right-click context menu on terminal tiles with Copy, Duplicate, and Paste options
- Add `pty:cwd` IPC to query the current working directory of a terminal session via tmux

## Demo
https://github.com/user-attachments/assets/917506be-4575-4a23-afd8-6ad917461e32

## Test plan

- [ ] Open a terminal tile, select text, press Cmd+C — verify text is copied to clipboard
- [ ] Press Cmd+V in a terminal tile — verify clipboard content is pasted
- [ ] Select a terminal tile on the canvas (click title bar), press Cmd+C then Cmd+V — verify a new terminal tile is created adjacent with the same working directory
- [ ] Multi-select terminal tiles, duplicate — verify all are duplicated
- [ ] Right-click a terminal tile — verify context menu shows Copy/Duplicate/Paste options
- [ ] Verify Shift+Enter still sends CSI u sequence (Claude Code newline)
- [ ] Verify Cmd+T and Cmd+1-9 are still passed through to the shell