### PR TITLE
Add terminal list rename, keyboard navigation, and focus management

### DIFF
--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -246,6 +246,7 @@ async function init() {
 				cwd: tile.cwd || "~",
 				foreground: null,
 				tileId: tile.id,
+				label: tile.label || null,
 			});
 		},
 		onTerminalTileClosed(sessionId) {
@@ -361,6 +362,11 @@ async function init() {
 
 		requestAnimationFrame(() => {
 			window.focus();
+			if (surface === "terminal-list") {
+				terminalListWebview.webview.focus();
+				noteSurfaceFocus("terminal-list");
+				return;
+			}
 			if (surface === "settings") {
 				singletonWebviews.settings.webview.focus();
 				noteSurfaceFocus("settings");
@@ -731,7 +737,15 @@ async function init() {
 		} else if (action === "add-workspace") {
 			wsAddOption.click();
 		} else if (action === "toggle-terminal-list") {
-			terminalPanel.toggle();
+			if (terminalPanel.isVisible() && activeSurface === "terminal-list") {
+				terminalPanel.setVisible(false);
+			} else {
+				if (!terminalPanel.isVisible()) {
+					terminalPanel.setVisible(true);
+				}
+				terminalListWebview.webview.focus();
+				focusSurface("terminal-list");
+			}
 		} else if (action === "new-tile") {
 			const rect = canvasEl.getBoundingClientRect();
 			const size = defaultSize("term");
@@ -955,6 +969,7 @@ async function init() {
 						cwd: disc?.meta?.cwd || "~",
 						foreground: null,
 						tileId: tile.id,
+						label: tile.label || null,
 					});
 				}
 			}
@@ -988,6 +1003,20 @@ async function init() {
 						break;
 					}
 				}
+			} else if (event.channel === "terminal-list:focus-tile") {
+				const sessionId = event.args[0];
+				for (const [id] of tileManager.getTileDOMs()) {
+					const tile = getTile(id);
+					if (tile?.type === "term" && tile.ptySessionId === sessionId) {
+						tileManager.focusCanvasTile(id);
+						break;
+					}
+				}
+			} else if (event.channel === "terminal-list:blur") {
+				focusSurface("canvas");
+			} else if (event.channel === "terminal-list:rename") {
+				const { sessionId, label } = event.args[0];
+				tileManager.updateTerminalLabel(sessionId, label);
 			}
 		},
 	);

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -57,6 +57,7 @@ export function createTileManager({
 				folderPath: t.folderPath,
 				workspacePath: t.workspacePath,
 				ptySessionId: t.ptySessionId,
+				label: t.label,
 				url: t.url,
 				zIndex: t.zIndex,
 			})),
@@ -611,6 +612,7 @@ export function createTileManager({
 						height: saved.height,
 						zIndex: saved.zIndex,
 						ptySessionId: saved.ptySessionId,
+						label: saved.label,
 					},
 				);
 				spawnTerminalWebview(tile);
@@ -646,6 +648,18 @@ export function createTileManager({
 	}
 
 	// -- Tile updates for external events --
+
+	function updateTerminalLabel(sessionId, label) {
+		for (const t of tiles) {
+			if (t.type === "term" && t.ptySessionId === sessionId) {
+				t.label = label || undefined;
+				const dom = tileDOMs.get(t.id);
+				if (dom) updateTileTitle(dom, t);
+				saveCanvasDebounced();
+				return;
+			}
+		}
+	}
 
 	function updateTileForRename(oldPath, newPath) {
 		let anyUpdated = false;
@@ -719,6 +733,7 @@ export function createTileManager({
 		getTileDOMs: () => tileDOMs,
 		getFocusedTileId: () => focusedTileId,
 		setFocusedTileId: (id) => { focusedTileId = id; },
+		updateTerminalLabel,
 		updateTileForRename,
 		closeTilesForDeletedPaths,
 		broadcastToTileWebviews,

--- a/collab-electron/src/windows/shell/src/tile-renderer.js
+++ b/collab-electron/src/windows/shell/src/tile-renderer.js
@@ -173,7 +173,7 @@ export function createTileDOM(tile, callbacks) {
 }
 
 export function getTileLabel(tile) {
-  if (tile.type === "term") return { parent: "", name: "Terminal" };
+  if (tile.type === "term") return { parent: "", name: tile.label || "Terminal" };
   if (tile.type === "browser") {
     if (tile.url) {
       try { return { parent: "", name: new URL(tile.url).hostname }; }

--- a/collab-electron/src/windows/terminal-list/src/App.css
+++ b/collab-electron/src/windows/terminal-list/src/App.css
@@ -100,6 +100,20 @@ body {
 .shell-name {
   font-weight: 500;
   white-space: nowrap;
+  cursor: default;
+}
+
+.rename-input {
+  font: inherit;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-focus);
+  border-radius: 3px;
+  color: inherit;
+  padding: 0 4px;
+  outline: none;
+  width: 100%;
+  min-width: 0;
 }
 
 .status-label {

--- a/collab-electron/src/windows/terminal-list/src/App.tsx
+++ b/collab-electron/src/windows/terminal-list/src/App.tsx
@@ -7,6 +7,7 @@ interface TerminalEntry {
   cwd: string;
   foreground: string | null;
   tileId: string;
+  label: string | null;
 }
 
 function shellBasename(shell: string): string {
@@ -23,6 +24,32 @@ function App() {
   const [entries, setEntries] = useState<TerminalEntry[]>([]);
   const [focusedSessionId, setFocusedSessionId] =
     useState<string | null>(null);
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  function startRename(entry: TerminalEntry) {
+    setEditingSessionId(entry.sessionId);
+    setEditValue(entry.label || shellBasename(entry.shell));
+  }
+
+  function commitRename(sessionId: string) {
+    const trimmed = editValue.trim();
+    const entry = entries.find((e) => e.sessionId === sessionId);
+    const shellName = entry ? shellBasename(entry.shell) : "";
+    const label = trimmed && trimmed !== shellName ? trimmed : null;
+    setEntries((prev) =>
+      prev.map((e) =>
+        e.sessionId === sessionId ? { ...e, label } : e,
+      ),
+    );
+    setEditingSessionId(null);
+    window.api.sendToHost("terminal-list:rename", { sessionId, label });
+  }
+
+  function cancelRename() {
+    setEditingSessionId(null);
+  }
+
   useEffect(() => {
     // Listen for messages from the shell renderer via webview.send()
     // These arrive on ipcRenderer.on() in the universal preload,
@@ -72,8 +99,26 @@ function App() {
     window.api.sendToHost("terminal-list:peek-tile", sessionId);
   }
 
+  function focusTile(sessionId: string) {
+    window.api.sendToHost("terminal-list:focus-tile", sessionId);
+  }
+
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (editingSessionId) return;
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        window.api.sendToHost("terminal-list:blur");
+        return;
+      }
+
+      if (e.key === "Enter" && focusedSessionId) {
+        e.preventDefault();
+        focusTile(focusedSessionId);
+        return;
+      }
+
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
       if (entries.length === 0) return;
 
@@ -93,7 +138,7 @@ function App() {
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [entries, focusedSessionId]);
+  }, [entries, focusedSessionId, editingSessionId]);
 
   return (
     <div className="terminal-list">
@@ -110,6 +155,9 @@ function App() {
           .filter(Boolean)
           .join(" ");
 
+        const isEditing = editingSessionId === entry.sessionId;
+        const displayName = entry.label || shellBasename(entry.shell);
+
         return (
           <div
             key={entry.sessionId}
@@ -119,9 +167,30 @@ function App() {
             <div className={`status-dot ${stateClass}`} />
             <div className="entry-info">
               <div className="entry-top">
-                <span className="shell-name">
-                  {shellBasename(entry.shell)}
-                </span>
+                {isEditing ? (
+                  <input
+                    className="rename-input"
+                    value={editValue}
+                    autoFocus
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitRename(entry.sessionId);
+                      if (e.key === "Escape") cancelRename();
+                    }}
+                    onBlur={() => commitRename(entry.sessionId)}
+                  />
+                ) : (
+                  <span
+                    className="shell-name"
+                    onDoubleClick={(e) => {
+                      e.stopPropagation();
+                      startRename(entry);
+                    }}
+                  >
+                    {displayName}
+                  </span>
+                )}
                 <span className="status-label">
                   {idle
                     ? "idle"


### PR DESCRIPTION
- Double-click terminal name to rename; persisted on tile and in canvas state
- Enter key focuses the selected terminal tile (starts typing in it)
- Escape returns focus from terminal list to canvas
- Ctrl+` opens and focuses terminal list; press again to close
- Custom labels shown in both terminal list and tile title bar