### PR TITLE
Add double-click tile title bar to center in viewport

### DIFF
--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -259,6 +259,9 @@ async function init() {
 				tile?.ptySessionId || null,
 			);
 		},
+		onTileDblClick(tile) {
+			edgeIndicators.panToTile(tile);
+		},
 	});
 
 	// -- Edge indicators --

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -22,6 +22,7 @@ export function createTileManager({
 	onTerminalSessionCreated,
 	onTerminalTileClosed,
 	onTileFocused,
+	onTileDblClick,
 }) {
 	/** @type {Map<string, {container: HTMLElement, contentArea: HTMLElement, titleText: HTMLElement, webview?: HTMLElement}>} */
 	const tileDOMs = new Map();
@@ -449,6 +450,12 @@ export function createTileManager({
 				spawnBrowserWebview(t);
 				saveCanvasImmediate();
 			},
+		});
+
+		// Double-click title bar → center tile in viewport
+		dom.titleBar.addEventListener("dblclick", (e) => {
+			e.stopPropagation();
+			if (onTileDblClick) onTileDblClick(tile);
 		});
 
 		attachDrag(dom.titleBar, tile, {


### PR DESCRIPTION
Double-clicking a tile's title bar smoothly pans the canvas to center that tile, reusing the existing panToTile animation from edge indicators.