### PR TITLE
Make terminal list click focus the tile instead of just peeking

### DIFF
--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -1010,6 +1010,21 @@ async function init() {
 						break;
 					}
 				}
+			} else if (event.channel === "terminal-list:focus-tile") {
+				const sessionId = event.args[0];
+				for (const [id] of tileManager.getTileDOMs()) {
+					const tile = getTile(id);
+					if (
+						tile?.type === "term" &&
+						tile.ptySessionId === sessionId
+					) {
+						edgeIndicators.panToTile(tile);
+						tileManager.focusCanvasTile(id);
+						break;
+					}
+				}
+			} else if (event.channel === "terminal-list:blur") {
+				focusSurface("canvas");
 			}
 		},
 	);

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -167,6 +167,21 @@ export function createTileManager({
 				tile.type !== "browser"
 			) {
 				forwardClickToWebview(dom.webview, mouseEvent);
+			} else if (!mouseEvent && tile.type === "term") {
+				// Programmatic focus (e.g. from terminal list) —
+				// simulate a click in the center so xterm grabs focus
+				setTimeout(() => {
+					try {
+						const x = Math.round(dom.webview.offsetWidth / 2);
+						const y = Math.round(dom.webview.offsetHeight / 2);
+						dom.webview.sendInputEvent({
+							type: "mouseDown", x, y, button: "left", clickCount: 1,
+						});
+						dom.webview.sendInputEvent({
+							type: "mouseUp", x, y, button: "left", clickCount: 1,
+						});
+					} catch { /* noop */ }
+				}, 100);
 			}
 		}
 	}

--- a/collab-electron/src/windows/terminal-list/src/App.tsx
+++ b/collab-electron/src/windows/terminal-list/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
           <div
             key={entry.sessionId}
             className={classes}
-            onClick={() => peekTile(entry.sessionId)}
+            onClick={() => focusTile(entry.sessionId)}
           >
             <div className={`status-dot ${stateClass}`} />
             <div className="entry-info">


### PR DESCRIPTION
Clicking a terminal entry in the sidebar now pans the canvas to the tile AND focuses it (bringing it to front with keyboard input ready). Previously clicking only panned without focusing, requiring two extra clicks to interact with the terminal.

- terminal-list App.tsx: click calls focusTile() instead of peekTile()
- renderer.js: add terminal-list:focus-tile handler that pans + focuses
- renderer.js: add terminal-list:blur handler for Escape key
- tile-manager.js: simulate a click in terminal webview center on programmatic focus so xterm grabs keyboard input immediately

Arrow keys still peek (pan without focus) for quick browsing. Enter focuses the peeked tile (existing behavior).