### PR TITLE
fix: remove forceDevUpdateConfig causing update error in dev mode

### DIFF
--- a/collab-electron/src/main/updater/update-manager.ts
+++ b/collab-electron/src/main/updater/update-manager.ts
@@ -97,8 +97,6 @@ class UpdateManager {
         CHECK_INTERVAL_MS,
       );
       powerMonitor.on("resume", () => this.checkForUpdates());
-    } else {
-      autoUpdater.forceDevUpdateConfig = true;
     }
 
     this.initialized = true;


### PR DESCRIPTION
## Summary

- Removed `autoUpdater.forceDevUpdateConfig = true` in the `else` branch of `app.isPackaged` check in `update-manager.ts`
- This setting attempts to read a `dev-app-update.yml` file that does not exist in the repo, causing an update failure dialog on every dev mode launch
- The `if (app.isPackaged)` guard already ensures update checks only run in production, so the `else` branch is unnecessary

## Test plan

- [x] Run `bun run dev` and confirm no update error dialog appears
- [ ] Run `bun run build` and verify packaged app still checks for updates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)