### PR TITLE
feat(terminal): add rename support for terminal tiles

### DIFF
--- a/collab-electron/src/main/canvas-persistence.ts
+++ b/collab-electron/src/main/canvas-persistence.ts
@@ -20,6 +20,7 @@ interface TileState {
   url?: string | null;
   workspacePath?: string;
   ptySessionId?: string;
+  customName?: string;
   zIndex: number;
 }
 

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -562,6 +562,7 @@ contextBridge.exposeInMainWorld("api", {
       "terminal-list:add",
       "terminal-list:remove",
       "terminal-list:focus",
+      "terminal-list:renamed",
       "pty-status-changed",
       "pty-exit",
     ];

--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -241,6 +241,7 @@ async function init() {
 			cwd: meta.cwdHostPath || meta.cwd || tile.cwd || "~",
 			foreground: null,
 			tileId: tile.id,
+			customName: tile.customName || null,
 		};
 	}
 
@@ -1044,6 +1045,13 @@ async function init() {
 						break;
 					}
 				}
+			} else if (event.channel === "terminal-list:rename") {
+				const { sessionId, name } = event.args[0];
+				tileManager.renameTerminal(sessionId, name);
+				terminalListWebview.send(
+					"terminal-list:renamed",
+					{ sessionId, name },
+				);
 			}
 		},
 	);

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -60,6 +60,7 @@ export function createTileManager({
 				workspacePath: t.workspacePath,
 				ptySessionId: t.ptySessionId,
 				url: t.url,
+				customName: t.customName || undefined,
 				zIndex: t.zIndex,
 			})),
 			viewport: {
@@ -627,6 +628,7 @@ export function createTileManager({
 						height: saved.height,
 						zIndex: saved.zIndex,
 						ptySessionId: saved.ptySessionId,
+						customName: saved.customName || null,
 					},
 				);
 				spawnTerminalWebview(tile);
@@ -709,6 +711,18 @@ export function createTileManager({
 		}
 	}
 
+	function renameTerminal(sessionId, name) {
+		for (const t of tiles) {
+			if (t.type === "term" && t.ptySessionId === sessionId) {
+				t.customName = name || null;
+				const dom = tileDOMs.get(t.id);
+				if (dom) updateTileTitle(dom, t);
+				saveCanvasDebounced();
+				break;
+			}
+		}
+	}
+
 	function broadcastToTileWebviews(channel, ...args) {
 		for (const [, dom] of tileDOMs) {
 			if (dom.webview) dom.webview.send(channel, ...args);
@@ -737,6 +751,7 @@ export function createTileManager({
 		updateTileForRename,
 		closeTilesForDeletedPaths,
 		broadcastToTileWebviews,
+		renameTerminal,
 		saveCanvasDebounced,
 		saveCanvasImmediate,
 	};

--- a/collab-electron/src/windows/shell/src/tile-renderer.js
+++ b/collab-electron/src/windows/shell/src/tile-renderer.js
@@ -176,6 +176,7 @@ export function createTileDOM(tile, callbacks) {
 
 export function getTileLabel(tile) {
   if (tile.type === "term") {
+    if (tile.customName) return { parent: "", name: tile.customName };
     if (tile.cwd) return splitFilepath(tile.cwd);
     if (tile.displayName) return { parent: "", name: tile.displayName };
     return { parent: "", name: "Terminal" };

--- a/collab-electron/src/windows/terminal-list/src/App.css
+++ b/collab-electron/src/windows/terminal-list/src/App.css
@@ -119,3 +119,37 @@ body {
   direction: rtl;
   text-align: left;
 }
+
+.rename-btn {
+  background: none;
+  border: none;
+  color: var(--muted, #888);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 2px;
+  opacity: 0;
+  transition: opacity 80ms ease;
+  flex-shrink: 0;
+}
+
+.terminal-entry:hover .rename-btn {
+  opacity: 1;
+}
+
+.rename-btn:hover {
+  color: var(--text, #ccc);
+}
+
+.rename-input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+  color: var(--text, #ccc);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 1px 4px;
+  outline: none;
+  width: 100%;
+  min-width: 0;
+}

--- a/collab-electron/src/windows/terminal-list/src/App.tsx
+++ b/collab-electron/src/windows/terminal-list/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { normalizeCommandName } from "@collab/shared/path-utils";
 import "./App.css";
 
@@ -9,6 +9,7 @@ interface TerminalEntry {
   cwd: string;
   foreground: string | null;
   tileId: string;
+  customName?: string | null;
 }
 
 function isIdle(entry: TerminalEntry): boolean {
@@ -47,6 +48,24 @@ function App() {
   const [entries, setEntries] = useState<TerminalEntry[]>([]);
   const [focusedSessionId, setFocusedSessionId] =
     useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const lastClickRef = useRef<{ id: string; time: number } | null>(null);
+
+  function startEditing(entry: TerminalEntry) {
+    setEditingId(entry.sessionId);
+    setEditValue(entry.customName || entry.displayName || "");
+  }
+
+  function commitRename(sessionId: string) {
+    const trimmed = editValue.trim();
+    window.api.sendToHost("terminal-list:rename", { sessionId, name: trimmed });
+    setEditingId(null);
+  }
+
+  function cancelEditing() {
+    setEditingId(null);
+  }
   useEffect(() => {
     // Listen for messages from the shell renderer via webview.send()
     // These arrive on ipcRenderer.on() in the universal preload,
@@ -81,6 +100,15 @@ function App() {
             prev.map((e) =>
               e.sessionId === payload.sessionId
                 ? { ...e, foreground: payload.foreground }
+                : e,
+            ),
+          );
+        } else if (channel === "terminal-list:renamed") {
+          const payload = args[0] as { sessionId: string; name: string };
+          setEntries((prev) =>
+            prev.map((e) =>
+              e.sessionId === payload.sessionId
+                ? { ...e, customName: payload.name || null }
                 : e,
             ),
           );
@@ -139,23 +167,70 @@ function App() {
           .filter(Boolean)
           .join(" ");
 
+        const displayLabel = entry.customName || entry.displayName;
+
         return (
           <div
             key={entry.tileId}
             className={classes}
-            onClick={() => peekTile(entry.sessionId)}
+            onClick={() => {
+              const now = Date.now();
+              const last = lastClickRef.current;
+              if (
+                last &&
+                last.id === entry.sessionId &&
+                now - last.time < 400
+              ) {
+                startEditing(entry);
+                lastClickRef.current = null;
+                return;
+              }
+              lastClickRef.current = { id: entry.sessionId, time: now };
+              peekTile(entry.sessionId);
+            }}
           >
             <div className={`status-dot ${stateClass}`} />
             <div className="entry-info">
               <div className="entry-top">
-                <span className="shell-name">
-                  {entry.displayName}
-                </span>
-                <span className="status-label">
-                  {idle
-                    ? "idle"
-                    : entry.foreground || "running"}
-                </span>
+                {editingId === entry.sessionId ? (
+                  <input
+                    className="rename-input"
+                    value={editValue}
+                    autoFocus
+                    onChange={(e) => setEditValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        commitRename(entry.sessionId);
+                      } else if (e.key === "Escape") {
+                        cancelEditing();
+                      }
+                      e.stopPropagation();
+                    }}
+                    onBlur={() => commitRename(entry.sessionId)}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <>
+                    <span className="shell-name">
+                      {displayLabel}
+                    </span>
+                    <button
+                      className="rename-btn"
+                      title="Rename"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        startEditing(entry);
+                      }}
+                    >
+                      ✎
+                    </button>
+                    <span className="status-label">
+                      {idle
+                        ? "idle"
+                        : entry.foreground || "running"}
+                    </span>
+                  </>
+                )}
               </div>
               <div className="entry-cwd">
                 {entry.cwd}


### PR DESCRIPTION
Adds the ability to rename terminal sessions from the terminal list panel (right sidebar). Custom names persist across restarts and sync with the tile title bar on the canvas.

**How it works:**
- Hover over a terminal entry in the list — a pencil icon (✎) appears
- Click the icon or double-click the terminal name to enter edit mode
- Type a new name, press Enter to save (or Escape to cancel)
- The tile title bar on the canvas updates immediately
- Names are stored in `canvas-state.json` as `customName` on each terminal tile

**Files changed (7):**
- `canvas-persistence.ts` — `customName?: string` added to `TileState`
- `tile-manager.js` — save/restore `customName`, new `renameTerminal()` method
- `tile-renderer.js` — `getTileLabel()` prioritizes `customName` for terminal tiles
- `renderer.js` — `terminal-list:rename` IPC handler, `customName` in list entries
- `terminal-list/App.tsx` — rename button, double-click edit, inline input
- `terminal-list/App.css` — `.rename-btn` and `.rename-input` styles
- `universal.ts` — `terminal-list:renamed` added to listener channels

**Testing:**
- Created terminal tiles, renamed via pencil button and double-click
- Verified name persists after app restart
- Verified tile title bar updates on canvas
- Verified empty name reverts to default (cwd/displayName)
- Verified Escape cancels edit without saving
- Build passes (`bun run build`)