### PR TITLE
feat: add canvas.launchTerminal RPC (closes #54)

### DIFF
--- a/collab-electron/src/main/canvas-rpc.ts
+++ b/collab-electron/src/main/canvas-rpc.ts
@@ -33,7 +33,7 @@ function sendToShell(
 
     shellWindow!.webContents.send("canvas:rpc-request", {
       requestId,
-      method,
+      method: method.replace(/^canvas\./, ""),
       params,
     });
   });
@@ -141,4 +141,23 @@ export function registerCanvasRpc(win: BrowserWindow): void {
       },
     },
   );
+
+  registerMethod(
+    "canvas.launchTerminal",
+    (params) => sendToShell("canvas.launchTerminal", params),
+    {
+      description:
+        "Launch a new terminal tile and optionally run a command in it",
+      params: {
+        command: "(optional) Shell command to execute after the terminal opens",
+        cwd: "(optional) Working directory for the terminal session",
+        title: "(optional) Display title for the tile",
+        session_id:
+          "(optional) External session identifier for tracking",
+        position: "(optional) {x, y} canvas coordinates",
+        size: "(optional) {width, height} in pixels",
+      },
+    },
+  );
+
 }

--- a/collab-electron/src/windows/shell/src/canvas-rpc.js
+++ b/collab-electron/src/windows/shell/src/canvas-rpc.js
@@ -161,6 +161,27 @@ export function createCanvasRpc({
 					result = {};
 					break;
 				}
+			case "launchTerminal": {
+				const size = defaultSize("term");
+				const pos = params.position
+					? { x: params.position.x, y: params.position.y }
+					: findAutoPlacement(tiles, size.width, size.height);
+
+				const extra = {};
+				if (params.size?.width) extra.width = params.size.width;
+				if (params.size?.height) extra.height = params.size.height;
+				if (params.cwd) extra.cwd = params.cwd;
+				if (params.command) extra.command = params.command;
+				if (params.title) extra.title = params.title;
+
+				const tile = tileManager.createCanvasTile(
+					"term", pos.x, pos.y, extra,
+				);
+				tileManager.spawnTerminalWebview(tile, true);
+				tileManager.saveCanvasImmediate();
+				result = { tileId: tile.id };
+				break;
+			}
 				default: {
 					respondError(
 						requestId, -32601,

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -194,6 +194,9 @@ export function createTileManager({
 		} else if (tile.cwd) {
 			params.set("cwd", tile.cwd);
 		}
+		if (tile.command) {
+			params.set("command", tile.command);
+		}
 		const qs = params.toString();
 		wv.setAttribute(
 			"src",

--- a/collab-electron/src/windows/shell/src/tile-renderer.js
+++ b/collab-electron/src/windows/shell/src/tile-renderer.js
@@ -175,6 +175,7 @@ export function createTileDOM(tile, callbacks) {
 }
 
 export function getTileLabel(tile) {
+  if (tile.title) return { parent: "", name: tile.title };
   if (tile.type === "term") {
     if (tile.cwd) return splitFilepath(tile.cwd);
     if (tile.displayName) return { parent: "", name: tile.displayName };

--- a/collab-electron/src/windows/terminal-tile/src/App.tsx
+++ b/collab-electron/src/windows/terminal-tile/src/App.tsx
@@ -32,6 +32,8 @@ function App() {
     const isRestored = params.get("restored") === "1";
     const cwd = params.get("cwd") || undefined;
 
+    const command = params.get("command") || undefined;
+
     const createFreshSession = (
       target?: string,
       nextCwd?: string,
@@ -44,6 +46,13 @@ function App() {
           window.api.notifyPtySessionId(
             result.sessionId,
           );
+          // If a command was provided (e.g. from canvas.launchTerminal),
+          // write it to the PTY after shell init
+          if (command) {
+            setTimeout(() => {
+              window.api.ptyWrite(result.sessionId, command + "\n");
+            }, 300);
+          }
         })
         .catch(() => {
           setExited(true);


### PR DESCRIPTION
## Summary

Implements `canvas.launchTerminal` JSON-RPC method so external tools can programmatically open terminal tiles with a command. This is the missing piece for orchestrators that spawn multiple agents in parallel so users can now visually monitor each agent in its own tile.

- **New RPC method**: `canvas.launchTerminal` with params: `command`, `cwd`, `title`, `session_id`, `position`, `size`
- **Command injection**: After the PTY session is created, the command is written to stdin with a 300ms delay for shell init
- **Custom tile titles**: Tiles can display a custom title (e.g. "keshro: Implement auth module")
- **Bug fix**: Strips `canvas.` prefix in `sendToShell` so renderer switch cases match (was broken for all canvas RPC methods)

### Data flow
```
External tool → JSON-RPC socket → canvas.launchTerminal
  → main process (canvas-rpc.ts) → IPC → renderer (canvas-rpc.js)
  → tile-manager creates "term" tile → spawns terminal webview
  → terminal-tile App.tsx creates PTY → writes command to PTY stdin
```

### Testing
```bash
SOCK=$(cat ~/.collaborator/socket-path)
echo '{"jsonrpc":"2.0","id":1,"method":"canvas.launchTerminal","params":{"command":"echo hello","cwd":"/tmp","title":"Test"}}' | socat - UNIX-CONNECT:$SOCK
# Returns: {"jsonrpc":"2.0","id":1,"result":{"tileId":"tile-..."}}
```

Tested locally with `bun run dev` — terminal tile appears, command executes, tile title shows correctly.

Closes #54