### PR TITLE
fix: refine canvas material fallback by platform

### DIFF
--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -17,6 +17,8 @@ import { normalizeCommandName } from "@collab/shared/path-utils";
 
 const CANVAS_DBLCLICK_SUPPRESS_MS = 500;
 const IS_WINDOWS = window.shellApi.getPlatform() === "win32";
+const IS_MAC = window.shellApi.getPlatform() === "darwin";
+const HAS_NATIVE_MATERIAL = IS_WINDOWS || IS_MAC;
 
 const viewportState = { panX: 0, panY: 0, zoom: 1 };
 
@@ -24,8 +26,14 @@ const canvasEl = document.getElementById("panel-viewer");
 const gridCanvas = document.getElementById("grid-canvas");
 canvasEl.tabIndex = -1;
 
-document.documentElement.classList.toggle("platform-win", IS_WINDOWS);
-document.body.classList.toggle("platform-win", IS_WINDOWS);
+document.documentElement.classList.toggle(
+	"platform-material",
+	HAS_NATIVE_MATERIAL,
+);
+document.body.classList.toggle(
+	"platform-material",
+	HAS_NATIVE_MATERIAL,
+);
 
 // -- Dark mode --
 

--- a/collab-electron/src/windows/shell/src/shell.css
+++ b/collab-electron/src/windows/shell/src/shell.css
@@ -26,9 +26,9 @@
 .dark {
 	--bg: rgb(18, 18, 18);
 	--bg-rgb: 18, 18, 18;
-	--canvas-bg: rgb(24, 24, 24);
-	--canvas-bg-hi: rgb(38, 38, 38);
-	--canvas-bg-rgb: 24, 24, 24;
+	--canvas-bg: rgb(46, 46, 46);
+	--canvas-bg-hi: rgb(60, 60, 60);
+	--canvas-bg-rgb: 46, 46, 46;
 	--fg: rgb(220, 220, 220);
 	--border: rgba(255, 255, 255, 0.2);
 	--tile-border: rgba(255, 255, 255, 0.35);
@@ -47,7 +47,7 @@ html,
 body {
 	height: 100%;
 	overflow: hidden;
-	background: transparent;
+	background: var(--bg);
 	color: var(--fg);
 	font-family: var(--font-mono);
 	-webkit-font-smoothing: antialiased;
@@ -57,11 +57,11 @@ body {
 	display: flex;
 	flex-direction: column;
 	padding: 0;
-	background: transparent;
+	background: var(--bg);
 }
 
-html.platform-win,
-body.platform-win {
+html.platform-material,
+body.platform-material {
 	background: transparent;
 }
 
@@ -126,7 +126,7 @@ body.platform-win {
 	background: rgba(var(--bg-rgb), calc(1 - (1 - var(--canvas-opacity)) / 2));
 }
 
-.platform-win #panel-nav {
+.platform-material #panel-nav {
 	background: rgba(var(--bg-rgb), calc(1 - (1 - var(--canvas-opacity)) / 2));
 }
 
@@ -164,12 +164,26 @@ body.platform-win {
 	min-width: 200px;
 	overflow: hidden;
 	position: relative;
-	background: rgba(var(--canvas-bg-rgb), var(--canvas-opacity));
+	background: var(--bg);
 	outline: none;
 }
 
-.platform-win #panel-viewer {
+#panel-viewer::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: var(--canvas-bg);
+	opacity: var(--canvas-opacity);
+	pointer-events: none;
+	z-index: 0;
+}
+
+.platform-material #panel-viewer {
 	background: rgba(var(--canvas-bg-rgb), var(--canvas-opacity));
+}
+
+.platform-material #panel-viewer::before {
+	display: none;
 }
 
 #grid-canvas {
@@ -177,7 +191,7 @@ body.platform-win {
 	inset: 0;
 	width: 100%;
 	height: 100%;
-	z-index: 0;
+	z-index: 1;
 	pointer-events: none;
 }
 
@@ -196,7 +210,7 @@ body.platform-win {
 	background: rgba(var(--bg-rgb), calc(1 - (1 - var(--canvas-opacity)) / 2));
 }
 
-.platform-win #panel-terminal {
+.platform-material #panel-terminal {
 	background: rgba(var(--bg-rgb), calc(1 - (1 - var(--canvas-opacity)) / 2));
 }
 


### PR DESCRIPTION
## Summary
Refine the canvas opacity treatment so macOS and Windows stay on the native material/translucency path, while Linux uses an opaque fallback canvas tint instead of exposing a white or transparent backing layer.

## Why
The shell was treating canvas opacity as true transparency everywhere, but that only works well on platforms with native backdrop/material support. Windows already had a usable OS-backed path, and macOS is designed around vibrancy as well. On Linux, lowering canvas opacity exposed an opaque white fallback or, with full-window transparency, the desktop itself. The renderer also encoded this distinction indirectly as OS-specific CSS instead of the actual capability it depended on.

## What changed
- Kept native material-backed translucency behavior for macOS and Windows in the shell renderer.
- Added a renderer-level `platform-material` capability class instead of branching shell styling directly on OS names.
- Changed the Linux/default shell path to use an opaque shell background with a canvas tint overlay rather than real panel transparency.
- Increased the dark-mode canvas tint contrast so opacity adjustments remain visible on Linux in dark mode.
- Kept the canvas grid above the fallback tint layer so the visual stacking remains correct.

## Validation
- `bun run tsc --noEmit`
- Manual reasoning pass against the shell renderer and BrowserWindow platform setup for macOS, Windows, and Linux behavior

## Risks / follow-ups
- This does not change the main-process BrowserWindow platform setup; it only makes the shell renderer semantics explicit and safer on Linux.
- Linux still uses a fallback visual model rather than true OS-backed translucency, so the setting is visually equivalent but not compositor-equivalent to macOS/Windows.
- I did not run a full packaged-app smoke test for all three platforms in this branch.

## Review focus
- Capability-based shell styling in `collab-electron/src/windows/shell/src/renderer.js` and `collab-electron/src/windows/shell/src/shell.css`
- Linux fallback canvas layering and dark-mode tint behavior in `collab-electron/src/windows/shell/src/shell.css`
- Alignment between shell renderer behavior and the existing macOS/Windows window-material setup in `collab-electron/src/main/index.ts`
