### PR TITLE
feat: add update channel selector (Default / Early Access) to Settings

### DIFF
--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -813,6 +813,7 @@ app.whenReady().then(async () => {
   setupUpdateIPC();
   updateManager.init({
     onBeforeQuit: () => shutdownBackgroundServices(),
+    allowPrerelease: getPref(config, "updateChannel") === "early-access",
   });
 
   try {

--- a/collab-electron/src/main/updater/update-manager.ts
+++ b/collab-electron/src/main/updater/update-manager.ts
@@ -52,6 +52,7 @@ class UpdateManager {
   private errorResetTimeout: NodeJS.Timeout | null = null;
   private checkInterval: NodeJS.Timeout | null = null;
   private onBeforeQuit: (() => Promise<void>) | null = null;
+  private allowPrerelease = false;
 
   private shouldIgnoreMissingReleaseMetadataError(message: string): boolean {
     if (!isMissingReleaseMetadataError(message)) {
@@ -61,12 +62,14 @@ class UpdateManager {
     return true;
   }
 
-  init(opts?: { onBeforeQuit?: () => Promise<void> }): void {
+  init(opts?: { onBeforeQuit?: () => Promise<void>; allowPrerelease?: boolean }): void {
     if (this.initialized) return;
     this.onBeforeQuit = opts?.onBeforeQuit ?? null;
+    this.allowPrerelease = opts?.allowPrerelease ?? false;
 
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
+    autoUpdater.allowPrerelease = this.allowPrerelease;
 
     // Per-platform/arch update channels so each build gets its own yml file.
     // Mac: latest-arm64-mac.yml / latest-x64-mac.yml
@@ -212,6 +215,16 @@ class UpdateManager {
     autoUpdater.quitAndInstall();
   }
 
+  setAllowPrerelease(allow: boolean): void {
+    this.allowPrerelease = allow;
+    autoUpdater.allowPrerelease = allow;
+    // Reset stale update state so the new channel is evaluated fresh.
+    if (this.state.status === "available" || this.state.status === "error") {
+      this.setState({ status: "idle", error: undefined, version: undefined });
+    }
+    void this.checkForUpdates();
+  }
+
   getState(): UpdateState {
     return { ...this.state };
   }
@@ -277,5 +290,10 @@ export function setupUpdateIPC(): void {
 
   ipcMain.on("update:install", async () => {
     await updateManager.install();
+  });
+
+  ipcMain.handle("update:setChannel", (_event, channel: string) => {
+    updateManager.setAllowPrerelease(channel === "early-access");
+    return updateManager.getState();
   });
 }

--- a/collab-electron/src/preload/shell.ts
+++ b/collab-electron/src/preload/shell.ts
@@ -142,6 +142,7 @@ contextBridge.exposeInMainWorld("shellApi", {
   updateCheck: () => ipcRenderer.invoke("update:check"),
   updateDownload: () => ipcRenderer.invoke("update:download"),
   updateInstall: () => ipcRenderer.send("update:install"),
+  updateSetChannel: (channel: string) => ipcRenderer.invoke("update:setChannel", channel),
   onUpdateStatus: (cb: (state: unknown) => void) => {
     const handler = (_event: unknown, state: unknown) => cb(state);
     ipcRenderer.on("update:status", handler);

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -25,6 +25,7 @@ interface SettingsApi {
   getAgents: () => Promise<AgentStatus[]>;
   installSkill: (agentId: string) => Promise<{ ok: boolean }>;
   uninstallSkill: (agentId: string) => Promise<{ ok: boolean }>;
+  updateSetChannel: (channel: string) => Promise<unknown>;
   close: () => void;
 }
 
@@ -175,9 +176,12 @@ function ThemeToggle({
   );
 }
 
+type UpdateChannel = "default" | "early-access";
+
 function AppearancePane() {
   const [theme, setTheme] = useState<ThemeMode>("system");
   const [canvasOpacity, setCanvasOpacity] = useState(0);
+  const [updateChannel, setUpdateChannel] = useState<UpdateChannel>("default");
 
   useEffect(() => {
     api.getPref("theme")
@@ -191,6 +195,12 @@ function AppearancePane() {
         if (typeof v === "number") setCanvasOpacity(v);
       })
       .catch(() => { });
+    api.getPref("updateChannel")
+      .then((v) => {
+        if (v === "early-access") setUpdateChannel("early-access");
+        else setUpdateChannel("default");
+      })
+      .catch(() => { });
   }, []);
 
   async function handleThemeChange(mode: ThemeMode) {
@@ -201,6 +211,12 @@ function AppearancePane() {
   async function handleOpacityChange(value: number) {
     setCanvasOpacity(value);
     await api.setPref("canvasOpacity", value);
+  }
+
+  async function handleUpdateChannelChange(channel: UpdateChannel) {
+    setUpdateChannel(channel);
+    await api.setPref("updateChannel", channel);
+    await api.updateSetChannel(channel);
   }
 
   return (
@@ -231,6 +247,33 @@ function AppearancePane() {
           value={canvasOpacity}
           onChange={(v) => { void handleOpacityChange(v); }}
         />
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Update Access</p>
+          <p className="text-xs text-muted-foreground" style={{ maxWidth: 240 }}>
+            By default, get notified for stable updates only. Early Access
+            builds may be unstable for production work.
+          </p>
+        </div>
+        <select
+          value={updateChannel}
+          onChange={(e) => { void handleUpdateChannelChange(e.target.value as UpdateChannel); }}
+          className="shrink-0 rounded-md px-2.5 py-1.5 text-xs font-medium cursor-pointer appearance-none"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--foreground) 8%, transparent)",
+            color: "var(--foreground)",
+            border: "1px solid color-mix(in srgb, var(--foreground) 20%, transparent)",
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='none' stroke='%23888' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M2 4l4 4 4-4'/%3E%3C/svg%3E")`,
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "right 8px center",
+            paddingRight: "28px",
+          }}
+        >
+          <option value="default">Default</option>
+          <option value="early-access">Early Access</option>
+        </select>
       </div>
     </div>
   );


### PR DESCRIPTION
## Why?

I wanted to try the latest ["pre-release" ](https://github.com/collaborator-ai/collab-public/releases) but it doesnt appear via auto update, similar to cursor this adds a small enable beta pre release access in the collaborator settings

## Summary

- Adds an **Update Access** dropdown to Settings → Appearance, mirroring Cursor's update channel UI
- Two options: **Default** (stable releases only) and **Early Access** (includes pre-releases)
- Selection persists to `~/.collaborator/config.json` and applies immediately — no restart required

## How it works

`electron-updater` already supports `allowPrerelease` natively. This PR wires it up end-to-end:

- `UpdateManager.init()` reads the stored `updateChannel` pref on startup and sets `autoUpdater.allowPrerelease`
- New `setAllowPrerelease()` method updates the flag live and immediately re-triggers an update check
- New `update:setChannel` IPC handler bridges renderer → main
- Shell preload exposes `updateSetChannel()`
- Settings `AppearancePane` reads/writes the pref and calls `updateSetChannel` on change

## Test plan

- [ ] Open Settings → Appearance → confirm "Update Access" row appears with "Default" selected
- [ ] Switch to "Early Access" → check main process logs for `[updater]` re-check
- [ ] Quit and relaunch → confirm "Early Access" selection persists
- [ ] Switch back to "Default" → confirm re-check fires and pre-release is no longer offered