### PR TITLE
fix: add configurable terminal font family

### DIFF
--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -75,14 +75,11 @@ function TerminalTab({
 			})
 			.catch(() => {});
 
-		const offPrefChanged =
-			typeof window.api.onPrefChanged === "function"
-				? window.api.onPrefChanged((key, value) => {
-					if (key === "terminalFontFamily") {
-						applyFontFamily(value);
-					}
-				})
-				: undefined;
+		const offPrefChanged = window.api.onPrefChanged((key, value) => {
+			if (key === "terminalFontFamily") {
+				applyFontFamily(value);
+			}
+		});
 
 		const unicode11 = new Unicode11Addon();
 		term.loadAddon(unicode11);

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -37,14 +37,10 @@ function TerminalTab({
 		const container = containerRef.current;
 		if (!container) return;
 		let isDisposed = false;
-		const isFontAvailable = (fontFamily: string) => {
-			if (!("fonts" in document)) return false;
-			try {
-				return document.fonts.check(`12px ${fontFamily}`);
-			} catch {
-				return false;
-			}
-		};
+
+		const prefersDark = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
 
 		const prefersDark = window.matchMedia(
 			"(prefers-color-scheme: dark)",
@@ -52,7 +48,7 @@ function TerminalTab({
 
 		const term = new Terminal({
 			theme: getTheme(),
-			fontFamily: resolveTerminalFontFamily(undefined, isFontAvailable),
+			fontFamily: resolveTerminalFontFamily(undefined),
 			fontSize: 12,
 			fontWeight: "300",
 			fontWeightBold: "500",
@@ -68,16 +64,29 @@ function TerminalTab({
 		term.loadAddon(fit);
 		term.open(container);
 		fitRef.current = fit;
-		void window.api.getPref("terminalFontFamily").then((value) => {
-			if (isDisposed) return;
-			const nextFontFamily = resolveTerminalFontFamily(
-				value,
-				isFontAvailable,
-			);
+
+		const applyFontFamily = (value: unknown) => {
+			const nextFontFamily = resolveTerminalFontFamily(value);
 			if (nextFontFamily === term.options.fontFamily) return;
 			term.options.fontFamily = nextFontFamily;
 			requestAnimationFrame(() => fit.fit());
-		}).catch(() => {});
+		};
+
+		void window.api.getPref("terminalFontFamily")
+			.then((value) => {
+				if (isDisposed) return;
+				applyFontFamily(value);
+			})
+			.catch(() => {});
+
+		const offPrefChanged =
+			typeof window.api.onPrefChanged === "function"
+				? window.api.onPrefChanged((key, value) => {
+					if (key === "terminalFontFamily") {
+						applyFontFamily(value);
+					}
+				})
+				: undefined;
 
 		const unicode11 = new Unicode11Addon();
 		term.loadAddon(unicode11);
@@ -407,6 +416,7 @@ function TerminalTab({
 			container.removeEventListener("dragover", handleDragOver);
 			container.removeEventListener("drop", handleDrop);
 			window.api.offPtyData(sessionId, handleData);
+			offPrefChanged?.();
 			offShellBlur();
 			term.dispose();
 			fitRef.current = null;

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -42,10 +42,6 @@ function TerminalTab({
 			"(prefers-color-scheme: dark)",
 		).matches;
 
-		const prefersDark = window.matchMedia(
-			"(prefers-color-scheme: dark)",
-		).matches;
-
 		const term = new Terminal({
 			theme: getTheme(),
 			fontFamily: resolveTerminalFontFamily(undefined),

--- a/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
+++ b/collab-electron/packages/components/src/Terminal/TerminalTab.tsx
@@ -3,6 +3,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { resolveTerminalFontFamily } from "@collab/shared/terminal-font";
 import { getTheme } from "./theme";
 import "@xterm/xterm/css/xterm.css";
 import "./TerminalTab.css";
@@ -35,6 +36,15 @@ function TerminalTab({
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
+		let isDisposed = false;
+		const isFontAvailable = (fontFamily: string) => {
+			if (!("fonts" in document)) return false;
+			try {
+				return document.fonts.check(`12px ${fontFamily}`);
+			} catch {
+				return false;
+			}
+		};
 
 		const prefersDark = window.matchMedia(
 			"(prefers-color-scheme: dark)",
@@ -42,7 +52,7 @@ function TerminalTab({
 
 		const term = new Terminal({
 			theme: getTheme(),
-			fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+			fontFamily: resolveTerminalFontFamily(undefined, isFontAvailable),
 			fontSize: 12,
 			fontWeight: "300",
 			fontWeightBold: "500",
@@ -58,6 +68,16 @@ function TerminalTab({
 		term.loadAddon(fit);
 		term.open(container);
 		fitRef.current = fit;
+		void window.api.getPref("terminalFontFamily").then((value) => {
+			if (isDisposed) return;
+			const nextFontFamily = resolveTerminalFontFamily(
+				value,
+				isFontAvailable,
+			);
+			if (nextFontFamily === term.options.fontFamily) return;
+			term.options.fontFamily = nextFontFamily;
+			requestAnimationFrame(() => fit.fit());
+		}).catch(() => {});
 
 		const unicode11 = new Unicode11Addon();
 		term.loadAddon(unicode11);
@@ -373,6 +393,7 @@ function TerminalTab({
 		mediaQuery.addEventListener("change", onThemeChange);
 
 		return () => {
+			isDisposed = true;
 			if (flushTimer !== undefined) {
 				clearTimeout(flushTimer);
 				flushData();

--- a/collab-electron/packages/shared/src/terminal-font.test.ts
+++ b/collab-electron/packages/shared/src/terminal-font.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   composeTerminalFontFamily,
   DEFAULT_TERMINAL_FONT_FAMILY,
-  pickInstalledTerminalFontFamily,
   resolveTerminalFontFamily,
 } from "./terminal-font";
 
@@ -14,15 +13,6 @@ describe("resolveTerminalFontFamily", () => {
     expect(resolveTerminalFontFamily(null)).toBe(
       DEFAULT_TERMINAL_FONT_FAMILY,
     );
-  });
-
-  test("returns the first installed mono-friendly nerd font when available", () => {
-    expect(
-      resolveTerminalFontFamily(
-        undefined,
-        (fontFamily) => fontFamily === '"FiraCode Nerd Font Mono"',
-      ),
-    ).toBe(composeTerminalFontFamily('"FiraCode Nerd Font Mono"'));
   });
 
   test("returns the default stack for blank strings", () => {
@@ -40,36 +30,18 @@ describe("resolveTerminalFontFamily", () => {
     );
   });
 
-  test("appends emoji and symbol fallbacks for a single face", () => {
-    const resolved = resolveTerminalFontFamily("FiraCode Nerd Font");
-    expect(resolved.startsWith("FiraCode Nerd Font,")).toBe(true);
+  test("appends fallbacks for a single family", () => {
+    const resolved = resolveTerminalFontFamily("FiraCode Nerd Font Mono");
+    expect(resolved.startsWith('"FiraCode Nerd Font Mono",')).toBe(true);
+    expect(resolved).toContain("Menlo");
     expect(resolved).toContain('"Segoe UI Emoji"');
-    expect(resolved).toContain('"Symbols Nerd Font Mono"');
-  });
-});
-
-describe("pickInstalledTerminalFontFamily", () => {
-  test("returns the first available candidate", () => {
-    expect(
-      pickInstalledTerminalFontFamily(
-        (fontFamily) =>
-          fontFamily === '"JetBrainsMono Nerd Font Mono"'
-          || fontFamily === '"FiraCode Nerd Font Mono"',
-      ),
-    ).toBe('"JetBrainsMono Nerd Font Mono"');
-  });
-
-  test("returns null when none of the candidates are installed", () => {
-    expect(pickInstalledTerminalFontFamily(() => false)).toBeNull();
   });
 });
 
 describe("composeTerminalFontFamily", () => {
   test("avoids duplicating the primary family when it is already in the fallback stack", () => {
-    const resolved = composeTerminalFontFamily('"Symbols Nerd Font Mono"');
+    const resolved = composeTerminalFontFamily("Menlo");
     const parts = resolved.split(",").map((part) => part.trim());
-    expect(
-      parts.filter((part) => part === '"Symbols Nerd Font Mono"').length,
-    ).toBe(1);
+    expect(parts.filter((part) => part === "Menlo").length).toBe(1);
   });
 });

--- a/collab-electron/packages/shared/src/terminal-font.test.ts
+++ b/collab-electron/packages/shared/src/terminal-font.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  composeTerminalFontFamily,
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  pickInstalledTerminalFontFamily,
+  resolveTerminalFontFamily,
+} from "./terminal-font";
+
+describe("resolveTerminalFontFamily", () => {
+  test("returns the default stack for missing values", () => {
+    expect(resolveTerminalFontFamily(undefined)).toBe(
+      DEFAULT_TERMINAL_FONT_FAMILY,
+    );
+    expect(resolveTerminalFontFamily(null)).toBe(
+      DEFAULT_TERMINAL_FONT_FAMILY,
+    );
+  });
+
+  test("returns the first installed mono-friendly nerd font when available", () => {
+    expect(
+      resolveTerminalFontFamily(
+        undefined,
+        (fontFamily) => fontFamily === '"FiraCode Nerd Font Mono"',
+      ),
+    ).toBe(composeTerminalFontFamily('"FiraCode Nerd Font Mono"'));
+  });
+
+  test("returns the default stack for blank strings", () => {
+    expect(resolveTerminalFontFamily("")).toBe(
+      DEFAULT_TERMINAL_FONT_FAMILY,
+    );
+    expect(resolveTerminalFontFamily("   ")).toBe(
+      DEFAULT_TERMINAL_FONT_FAMILY,
+    );
+  });
+
+  test("preserves a user-provided font stack", () => {
+    expect(resolveTerminalFontFamily('Monaspace Neon, monospace')).toBe(
+      "Monaspace Neon, monospace",
+    );
+  });
+
+  test("appends emoji and symbol fallbacks for a single face", () => {
+    const resolved = resolveTerminalFontFamily("FiraCode Nerd Font");
+    expect(resolved.startsWith("FiraCode Nerd Font,")).toBe(true);
+    expect(resolved).toContain('"Segoe UI Emoji"');
+    expect(resolved).toContain('"Symbols Nerd Font Mono"');
+  });
+});
+
+describe("pickInstalledTerminalFontFamily", () => {
+  test("returns the first available candidate", () => {
+    expect(
+      pickInstalledTerminalFontFamily(
+        (fontFamily) =>
+          fontFamily === '"JetBrainsMono Nerd Font Mono"'
+          || fontFamily === '"FiraCode Nerd Font Mono"',
+      ),
+    ).toBe('"JetBrainsMono Nerd Font Mono"');
+  });
+
+  test("returns null when none of the candidates are installed", () => {
+    expect(pickInstalledTerminalFontFamily(() => false)).toBeNull();
+  });
+});
+
+describe("composeTerminalFontFamily", () => {
+  test("avoids duplicating the primary family when it is already in the fallback stack", () => {
+    const resolved = composeTerminalFontFamily('"Symbols Nerd Font Mono"');
+    const parts = resolved.split(",").map((part) => part.trim());
+    expect(
+      parts.filter((part) => part === '"Symbols Nerd Font Mono"').length,
+    ).toBe(1);
+  });
+});

--- a/collab-electron/packages/shared/src/terminal-font.ts
+++ b/collab-electron/packages/shared/src/terminal-font.ts
@@ -1,0 +1,101 @@
+const TERMINAL_PRIMARY_FONT_CANDIDATES = [
+  '"CaskaydiaMono Nerd Font Mono"',
+  '"CaskaydiaMono Nerd Font"',
+  '"CaskaydiaCove Nerd Font Mono"',
+  '"CaskaydiaCove Nerd Font"',
+  '"JetBrainsMono Nerd Font Mono"',
+  '"JetBrainsMono Nerd Font"',
+  '"MesloLGS NF"',
+  '"MesloLGS Nerd Font"',
+  '"SauceCodePro Nerd Font Mono"',
+  '"SauceCodePro Nerd Font"',
+  '"FiraCode Nerd Font Mono"',
+  '"FiraCode Nerd Font"',
+  '"Hack Nerd Font Mono"',
+  '"Hack Nerd Font"',
+  '"Symbols Nerd Font Mono"',
+  '"Symbols Nerd Font"',
+];
+
+const TERMINAL_FALLBACK_FONT_FAMILIES = [
+  ...TERMINAL_PRIMARY_FONT_CANDIDATES,
+  '"SF Mono"',
+  '"Cascadia Mono"',
+  "Consolas",
+  "Menlo",
+  "Monaco",
+  '"DejaVu Sans Mono"',
+  '"Liberation Mono"',
+  '"Noto Sans Mono"',
+  '"Segoe UI Emoji"',
+  '"Segoe UI Symbol"',
+  '"Apple Color Emoji"',
+  '"Noto Color Emoji"',
+  '"Noto Emoji"',
+  "monospace",
+];
+
+export type FontAvailabilityCheck = (fontFamily: string) => boolean;
+
+export const DEFAULT_TERMINAL_FONT_FAMILY = TERMINAL_FALLBACK_FONT_FAMILIES.join(
+  ", ",
+);
+
+function normalizeFontFamilyToken(value: string): string {
+  return value.trim().replace(/^['"]|['"]$/g, "").toLowerCase();
+}
+
+export function composeTerminalFontFamily(
+  primaryFontFamily?: string | null,
+): string {
+  const requested = typeof primaryFontFamily === "string"
+    ? primaryFontFamily.trim()
+    : "";
+
+  if (!requested) {
+    return DEFAULT_TERMINAL_FONT_FAMILY;
+  }
+
+  if (requested.includes(",")) {
+    return requested;
+  }
+
+  const seen = new Set<string>([normalizeFontFamilyToken(requested)]);
+  const families = [requested];
+
+  for (const fallback of TERMINAL_FALLBACK_FONT_FAMILIES) {
+    const normalized = normalizeFontFamilyToken(fallback);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    families.push(fallback);
+  }
+
+  return families.join(", ");
+}
+
+export function pickInstalledTerminalFontFamily(
+  isFontAvailable?: FontAvailabilityCheck,
+): string | null {
+  if (!isFontAvailable) return null;
+
+  for (const candidate of TERMINAL_PRIMARY_FONT_CANDIDATES) {
+    if (isFontAvailable(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function resolveTerminalFontFamily(
+  value: unknown,
+  isFontAvailable?: FontAvailabilityCheck,
+): string {
+  if (typeof value !== "string" || !value.trim()) {
+    return composeTerminalFontFamily(
+      pickInstalledTerminalFontFamily(isFontAvailable),
+    );
+  }
+
+  return composeTerminalFontFamily(value);
+}

--- a/collab-electron/packages/shared/src/terminal-font.ts
+++ b/collab-electron/packages/shared/src/terminal-font.ts
@@ -1,41 +1,24 @@
-const TERMINAL_PRIMARY_FONT_CANDIDATES = [
-  '"CaskaydiaMono Nerd Font Mono"',
-  '"CaskaydiaMono Nerd Font"',
-  '"CaskaydiaCove Nerd Font Mono"',
-  '"CaskaydiaCove Nerd Font"',
-  '"JetBrainsMono Nerd Font Mono"',
-  '"JetBrainsMono Nerd Font"',
-  '"MesloLGS NF"',
-  '"MesloLGS Nerd Font"',
-  '"SauceCodePro Nerd Font Mono"',
-  '"SauceCodePro Nerd Font"',
-  '"FiraCode Nerd Font Mono"',
-  '"FiraCode Nerd Font"',
-  '"Hack Nerd Font Mono"',
-  '"Hack Nerd Font"',
-  '"Symbols Nerd Font Mono"',
-  '"Symbols Nerd Font"',
-];
-
 const TERMINAL_FALLBACK_FONT_FAMILIES = [
-  ...TERMINAL_PRIMARY_FONT_CANDIDATES,
-  '"SF Mono"',
-  '"Cascadia Mono"',
-  "Consolas",
   "Menlo",
   "Monaco",
-  '"DejaVu Sans Mono"',
-  '"Liberation Mono"',
-  '"Noto Sans Mono"',
+  '"Courier New"',
   '"Segoe UI Emoji"',
   '"Segoe UI Symbol"',
   '"Apple Color Emoji"',
   '"Noto Color Emoji"',
-  '"Noto Emoji"',
   "monospace",
 ];
 
-export type FontAvailabilityCheck = (fontFamily: string) => boolean;
+export const TERMINAL_FONT_SUGGESTIONS = [
+  "FiraCode Nerd Font Mono",
+  "FiraCode Nerd Font",
+  "JetBrainsMono Nerd Font Mono",
+  "CaskaydiaMono Nerd Font Mono",
+  "MesloLGS NF",
+  "Hack Nerd Font Mono",
+  "SF Mono",
+  "Consolas",
+];
 
 export const DEFAULT_TERMINAL_FONT_FAMILY = TERMINAL_FALLBACK_FONT_FAMILIES.join(
   ", ",
@@ -43,6 +26,14 @@ export const DEFAULT_TERMINAL_FONT_FAMILY = TERMINAL_FALLBACK_FONT_FAMILIES.join
 
 function normalizeFontFamilyToken(value: string): string {
   return value.trim().replace(/^['"]|['"]$/g, "").toLowerCase();
+}
+
+function quoteFontFamily(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^['"].*['"]$/.test(trimmed)) return trimmed;
+  if (/^[A-Za-z0-9_-]+$/.test(trimmed)) return trimmed;
+  return `"${trimmed.replace(/"/g, '\\"')}"`;
 }
 
 export function composeTerminalFontFamily(
@@ -60,8 +51,9 @@ export function composeTerminalFontFamily(
     return requested;
   }
 
-  const seen = new Set<string>([normalizeFontFamilyToken(requested)]);
-  const families = [requested];
+  const primary = quoteFontFamily(requested);
+  const seen = new Set<string>([normalizeFontFamilyToken(primary)]);
+  const families = [primary];
 
   for (const fallback of TERMINAL_FALLBACK_FONT_FAMILIES) {
     const normalized = normalizeFontFamilyToken(fallback);
@@ -73,28 +65,9 @@ export function composeTerminalFontFamily(
   return families.join(", ");
 }
 
-export function pickInstalledTerminalFontFamily(
-  isFontAvailable?: FontAvailabilityCheck,
-): string | null {
-  if (!isFontAvailable) return null;
-
-  for (const candidate of TERMINAL_PRIMARY_FONT_CANDIDATES) {
-    if (isFontAvailable(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
-
-export function resolveTerminalFontFamily(
-  value: unknown,
-  isFontAvailable?: FontAvailabilityCheck,
-): string {
+export function resolveTerminalFontFamily(value: unknown): string {
   if (typeof value !== "string" || !value.trim()) {
-    return composeTerminalFontFamily(
-      pickInstalledTerminalFontFamily(isFontAvailable),
-    );
+    return DEFAULT_TERMINAL_FONT_FAMILY;
   }
 
   return composeTerminalFontFamily(value);

--- a/collab-electron/packages/shared/src/terminal-font.ts
+++ b/collab-electron/packages/shared/src/terminal-font.ts
@@ -66,9 +66,7 @@ export function composeTerminalFontFamily(
 }
 
 export function resolveTerminalFontFamily(value: unknown): string {
-  if (typeof value !== "string" || !value.trim()) {
-    return DEFAULT_TERMINAL_FONT_FAMILY;
-  }
-
-  return composeTerminalFontFamily(value);
+  return composeTerminalFontFamily(
+    typeof value === "string" ? value : null,
+  );
 }

--- a/collab-electron/packages/shared/src/window-api.d.ts
+++ b/collab-electron/packages/shared/src/window-api.d.ts
@@ -119,6 +119,9 @@ export interface CollabApi {
   getDeviceId: () => Promise<string>;
   getPref: (key: string) => Promise<unknown>;
   setPref: (key: string, value: unknown) => Promise<void>;
+  onPrefChanged: (
+    cb: (key: string, value: unknown) => void,
+  ) => Unsubscribe;
   listTerminalTargets: () => Promise<TerminalTargetOption[]>;
   getWorkspacePref: (key: string, workspacePath: string) => Promise<unknown>;
   setWorkspacePref: (
@@ -266,6 +269,7 @@ export interface CollabApi {
     backend?: "tmux" | "sidecar";
   } | null>;
   notifyPtySessionId: (sessionId: string) => void;
+  notifyCwdChanged: (sessionId: string, cwd: string) => void;
   onPtyData: (sessionId: string, cb: PtyDataCb) => void;
   offPtyData: (sessionId: string, cb: PtyDataCb) => void;
   onPtyExit: (sessionId: string, cb: PtyExitCb) => void;

--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -299,6 +299,12 @@ function applyZoomToAll(level: number): void {
   }
 }
 
+function sendToAllWebContents(channel: string, ...args: unknown[]): void {
+  for (const wc of webContentsModule.getAllWebContents()) {
+    if (!wc.isDestroyed()) wc.send(channel, ...args);
+  }
+}
+
 function buildAppMenu(): void {
   const isMac = process.platform === "darwin";
   const fullScreenAccelerator = isMac ? "Ctrl+Cmd+F" : "F11";
@@ -548,9 +554,7 @@ ipcMain.handle(
   "pref:set",
   (_event, key: string, value: unknown) => {
     setPref(config, key, value);
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send("pref:changed", key, value);
-    }
+    sendToAllWebContents("pref:changed", key, value);
   },
 );
 

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -154,6 +154,12 @@ contextBridge.exposeInMainWorld("api", {
   getPref: (key: string) => ipcRenderer.invoke("pref:get", key),
   setPref: (key: string, value: unknown) =>
     ipcRenderer.invoke("pref:set", key, value),
+  onPrefChanged: (cb: (key: string, value: unknown) => void) => {
+    const handler = (_event: unknown, key: string, value: unknown) =>
+      cb(key, value);
+    ipcRenderer.on("pref:changed", handler);
+    return () => ipcRenderer.removeListener("pref:changed", handler);
+  },
   listTerminalTargets: () =>
     ipcRenderer.invoke("terminal:list-targets"),
   getWorkspacePref: (key: string, workspacePath: string) =>

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -9,7 +9,10 @@ import {
   Monitor,
   Terminal,
 } from "@phosphor-icons/react";
-import { DEFAULT_TERMINAL_FONT_FAMILY } from "@collab/shared/terminal-font";
+import {
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  TERMINAL_FONT_SUGGESTIONS,
+} from "@collab/shared/terminal-font";
 
 type ThemeMode = "light" | "dark" | "system";
 
@@ -494,7 +497,7 @@ function TerminalFontField() {
         }
         setValue("");
       })
-      .catch(() => { });
+      .catch(() => {});
   }, []);
 
   async function commit(nextValue: string) {
@@ -508,16 +511,17 @@ function TerminalFontField() {
       <div className="space-y-0.5">
         <p className="text-sm font-medium">Terminal font family</p>
         <p className="text-xs text-muted-foreground">
-          Comma-separated CSS font stack. Reset uses the built-in mono-first
-          Nerd Font fallback. On WSLg and Linux, the fonts must be installed in
-          the distro so the embedded terminal can see them.
+          Enter a font family like FiraCode Nerd Font Mono or a full CSS stack.
+          Single-family entries keep the built-in fallback stack behind them.
+          Open terminals update immediately.
         </p>
       </div>
       <div className="flex items-center gap-2">
         <input
           type="text"
+          list="terminal-font-suggestions"
           value={value}
-          placeholder={DEFAULT_TERMINAL_FONT_FAMILY}
+          placeholder="e.g. FiraCode Nerd Font Mono"
           onChange={(event) => setValue(event.target.value)}
           onBlur={(event) => { void commit(event.target.value); }}
           onKeyDown={(event) => {
@@ -535,6 +539,11 @@ function TerminalFontField() {
             color: "var(--foreground)",
           }}
         />
+        <datalist id="terminal-font-suggestions">
+          {TERMINAL_FONT_SUGGESTIONS.map((fontFamily) => (
+            <option key={fontFamily} value={fontFamily} />
+          ))}
+        </datalist>
         <button
           type="button"
           onClick={() => {
@@ -551,6 +560,9 @@ function TerminalFontField() {
           Reset
         </button>
       </div>
+      <p className="text-[11px] text-muted-foreground font-mono">
+        Default: {DEFAULT_TERMINAL_FONT_FAMILY}
+      </p>
     </div>
   );
 }

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -490,13 +490,7 @@ function TerminalFontField() {
 
   useEffect(() => {
     api.getPref("terminalFontFamily")
-      .then((pref) => {
-        if (typeof pref === "string") {
-          setValue(pref);
-          return;
-        }
-        setValue("");
-      })
+      .then((pref) => setValue(typeof pref === "string" ? pref : ""))
       .catch(() => {});
   }, []);
 
@@ -546,10 +540,7 @@ function TerminalFontField() {
         </datalist>
         <button
           type="button"
-          onClick={() => {
-            setValue("");
-            void api.setPref("terminalFontFamily", null);
-          }}
+          onClick={() => { void commit(""); }}
           className="rounded-md px-3 py-2 text-xs font-medium cursor-pointer"
           style={{
             backgroundColor:

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Monitor,
   Terminal,
 } from "@phosphor-icons/react";
+import { DEFAULT_TERMINAL_FONT_FAMILY } from "@collab/shared/terminal-font";
 
 type ThemeMode = "light" | "dark" | "system";
 
@@ -424,6 +425,8 @@ function MacTerminalPane() {
           ))}
         </div>
       </div>
+
+      <TerminalFontField />
     </div>
   );
 }
@@ -472,6 +475,81 @@ function WindowsTerminalPane() {
             />
           ))}
         </div>
+      </div>
+
+      <TerminalFontField />
+    </div>
+  );
+}
+
+function TerminalFontField() {
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    api.getPref("terminalFontFamily")
+      .then((pref) => {
+        if (typeof pref === "string") {
+          setValue(pref);
+          return;
+        }
+        setValue("");
+      })
+      .catch(() => { });
+  }, []);
+
+  async function commit(nextValue: string) {
+    const trimmed = nextValue.trim();
+    setValue(trimmed);
+    await api.setPref("terminalFontFamily", trimmed || null);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <p className="text-sm font-medium">Terminal font family</p>
+        <p className="text-xs text-muted-foreground">
+          Comma-separated CSS font stack. Reset uses the built-in mono-first
+          Nerd Font fallback. On WSLg and Linux, the fonts must be installed in
+          the distro so the embedded terminal can see them.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={value}
+          placeholder={DEFAULT_TERMINAL_FONT_FAMILY}
+          onChange={(event) => setValue(event.target.value)}
+          onBlur={(event) => { void commit(event.target.value); }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              event.currentTarget.blur();
+            }
+          }}
+          className="w-full rounded-md px-3 py-2 text-sm font-mono"
+          style={{
+            backgroundColor:
+              "color-mix(in srgb, var(--foreground) 4%, transparent)",
+            border:
+              "1px solid color-mix(in srgb, var(--foreground) 12%, transparent)",
+            color: "var(--foreground)",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setValue("");
+            void api.setPref("terminalFontFamily", null);
+          }}
+          className="rounded-md px-3 py-2 text-xs font-medium cursor-pointer"
+          style={{
+            backgroundColor:
+              "color-mix(in srgb, var(--foreground) 8%, transparent)",
+            color: "var(--foreground)",
+          }}
+        >
+          Reset
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Make the embedded terminal font configurable from Settings so users can explicitly choose a Nerd Font such as `FiraCode Nerd Font Mono`, while keeping fallback composition and updating open terminals when the preference changes.

## Why
The terminal still defaulted to a generic Menlo/Monaco/Courier stack, so installing a Nerd Font alone was not enough to make icon-heavy TUIs render with the intended font. Instead of auto-picking a detected font, this change makes the preference explicit and user-controlled.

## What changed
- Added a shared terminal font helper that composes a single requested family with the existing fallback stack.
- Updated the xterm terminal view to resolve `terminalFontFamily` from prefs and react to `pref:changed` so open terminals pick up the new font immediately.
- Broadcast preference changes to all webContents and exposed `onPrefChanged` in the universal preload API.
- Added a `Terminal font family` field in Settings with common suggestions and reset behavior.
- Added focused tests for terminal font resolution and duplicate suppression.

## Validation
- `bun test packages/shared/src/terminal-font.test.ts`
- `bun x tsc --noEmit --pretty false`

## Notes
- This does not install fonts for the user. The chosen font still has to be installed where the embedded Chromium renderer can see it.
- Single-family entries like `FiraCode Nerd Font Mono` are expanded with the built-in fallback stack automatically.

## Video

https://github.com/user-attachments/assets/1b229c60-1d8d-496c-9ad4-45f09dec2ec1


