### PR TITLE
feat: fade minimap out after 1.5s idle, snap back instantly on movement

### DIFF
--- a/collab-electron/src/windows/shell/src/canvas-minimap.js
+++ b/collab-electron/src/windows/shell/src/canvas-minimap.js
@@ -193,7 +193,21 @@ export function createMinimap({ viewportEl, wrapperEl, viewportState, getTiles, 
 		});
 	}
 
-	function updateVisibility() {
+	resizeCanvas();
+
+	let idleTimer = null;
+
+	function scheduleIdle() {
+		clearTimeout(idleTimer);
+		wrapperEl.classList.remove("idle");
+		idleTimer = setTimeout(() => {
+			if (wrapperEl.classList.contains("visible")) {
+				wrapperEl.classList.add("idle");
+			}
+		}, 1500);
+	}
+
+	function updateVisibilityWithIdle() {
 		const tiles = getTiles();
 		const shouldShow = tiles.length > 0;
 		const isShown = wrapperEl.classList.contains("visible");
@@ -201,18 +215,20 @@ export function createMinimap({ viewportEl, wrapperEl, viewportState, getTiles, 
 		if (shouldShow && !isShown) {
 			wrapperEl.classList.add("visible");
 			canvasEl.style.setProperty("--zoom-indicator-bottom", "136px");
+			scheduleIdle();
 		} else if (!shouldShow && isShown) {
+			clearTimeout(idleTimer);
+			wrapperEl.classList.remove("idle");
 			wrapperEl.classList.remove("visible");
 			canvasEl.style.setProperty("--zoom-indicator-bottom", "12px");
 		}
 	}
 
-	resizeCanvas();
-
 	const minimap = {
 		update() {
-			updateVisibility();
+			updateVisibilityWithIdle();
 			scheduleRedraw();
+			scheduleIdle();
 		},
 		getViewportRect() {
 			if (!bounds) return null;

--- a/collab-electron/src/windows/shell/src/shell.css
+++ b/collab-electron/src/windows/shell/src/shell.css
@@ -745,6 +745,13 @@ body.platform-win {
 #minimap-wrapper.visible {
 	opacity: 1;
 	pointer-events: auto;
+	transition: opacity 0ms;
+}
+
+#minimap-wrapper.visible.idle {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 600ms ease;
 }
 
 #minimap-canvas {


### PR DESCRIPTION
## Why

The minimap is always visible whenever tiles are on the canvas which is almost always. It's useful context during navigation, but once you've stopped panning or zooming it just sits there taking up corner space. Auto-hiding it when you're not actively navigating keeps the canvas clean.

## Changes

| File | What changed |
|---|---|
| `src/windows/shell/src/canvas-minimap.js` | Adds `scheduleIdle()` — called on every `update()` (each pan/zoom), it clears the idle class immediately (instant show) then sets a 1.5s timeout to add it back. Timer is also cleared cleanly when all tiles are removed. |
| `src/windows/shell/src/shell.css` | `.visible` gets `transition: opacity 0ms` (instant snap-back); `.visible.idle` overrides with `transition: opacity 600ms ease` (slow fade out). CSS applies the after-state transition so each direction gets the right duration automatically. |