### PR TITLE
feat: add canvas annotation system (rect, line, text draw tools)

### DIFF
--- a/collab-electron/src/main/canvas-persistence.ts
+++ b/collab-electron/src/main/canvas-persistence.ts
@@ -25,9 +25,16 @@ interface TileState {
   zIndex: number;
 }
 
+type AnnotationState =
+  | { id: string; type: "rect"; x: number; y: number; width: number; height: number; color: string }
+  | { id: string; type: "text"; x: number; y: number; content: string; fontSize: number; color: string }
+  | { id: string; type: "line"; mode: "free"; x1: number; y1: number; x2: number; y2: number; color: string }
+  | { id: string; type: "line"; mode: "connected"; fromTileId: string; toTileId: string; color: string };
+
 interface CanvasState {
   version: 1;
   tiles: TileState[];
+  annotations?: AnnotationState[];
   viewport: {
     centerX: number;
     centerY: number;

--- a/collab-electron/src/windows/shell/index.html
+++ b/collab-electron/src/windows/shell/index.html
@@ -42,7 +42,26 @@
 					<path d="M228,128a12,12,0,0,1-12,12H140v76a12,12,0,0,1-24,0V140H40a12,12,0,0,1,0-24h76V40a12,12,0,0,1,24,0v76h76A12,12,0,0,1,228,128Z"/>
 				</svg>
 			</button>
+			<button type="button" id="draw-btn" aria-label="Annotate canvas" data-tooltip="Annotate canvas">
+				<svg width="15" height="15" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+					<path d="M227.31,73.37,182.63,28.68a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H92.69A15.86,15.86,0,0,0,104,219.31L227.31,96a16,16,0,0,0,0-22.63ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.68,147.31,64l24-24L216,84.68Z"/>
+				</svg>
+			</button>
+			<div id="draw-popover" class="hidden">
+				<button class="draw-tool-btn" data-tool="rect" title="Rectangle group">
+					<svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z"/></svg>
+				</button>
+				<button class="draw-tool-btn" data-tool="line" title="Line connector">
+					<svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor"><path d="M213.66,42.34a8,8,0,0,0-11.32,0l-160,160a8,8,0,0,0,11.32,11.32l160-160A8,8,0,0,0,213.66,42.34Z"/></svg>
+				</button>
+				<button class="draw-tool-btn" data-tool="text" title="Text label">
+					<svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor"><path d="M208,56H48A16,16,0,0,0,32,72V96a8,8,0,0,0,16,0V72H120v112H96a8,8,0,0,0,0,16h64a8,8,0,0,0,0-16H136V72h72V96a8,8,0,0,0,16,0V72A16,16,0,0,0,208,56Z"/></svg>
+				</button>
+			</div>
 			<canvas id="grid-canvas"></canvas>
+			<div id="annotation-layer">
+				<svg id="annotation-svg" xmlns="http://www.w3.org/2000/svg"></svg>
+			</div>
 			<div id="tile-layer"></div>
 			<div id="edge-indicators"></div>
 			<div id="zoom-indicator">100%</div>

--- a/collab-electron/src/windows/shell/src/annotation-manager.ts
+++ b/collab-electron/src/windows/shell/src/annotation-manager.ts
@@ -48,29 +48,14 @@ export type Annotation =
 
 export const annotations: Annotation[] = [];
 
-let idCounter = 0;
-
 let currentMode: DrawMode = "pointer";
 
 export function generateAnnotationId(): string {
-	idCounter++;
-	return `ann-${Date.now()}-${idCounter}`;
+	return `ann-${Date.now()}`;
 }
 
 export function getDefaultAnnotationColor(): string {
-	const raw = getComputedStyle(document.documentElement)
-		.getPropertyValue("--muted")
-		.trim();
-	const m = raw.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-	if (m) {
-		return (
-			"#" +
-			[m[1]!, m[2]!, m[3]!]
-				.map((v) => parseInt(v, 10).toString(16).padStart(2, "0"))
-				.join("")
-		);
-	}
-	return "#888888";
+	return document.documentElement.classList.contains("dark") ? "#848484" : "#71717b";
 }
 
 export function addAnnotation(data: Omit<Annotation, "id">): Annotation {

--- a/collab-electron/src/windows/shell/src/annotation-manager.ts
+++ b/collab-electron/src/windows/shell/src/annotation-manager.ts
@@ -1,0 +1,212 @@
+export type DrawMode = "pointer" | "draw-rect" | "draw-text" | "draw-line";
+
+export type AnnotationRect = {
+	id: string;
+	type: "rect";
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	color: string;
+};
+
+export type AnnotationText = {
+	id: string;
+	type: "text";
+	x: number;
+	y: number;
+	content: string;
+	fontSize: number;
+	color: string;
+};
+
+export type AnnotationLineFree = {
+	id: string;
+	type: "line";
+	mode: "free";
+	x1: number;
+	y1: number;
+	x2: number;
+	y2: number;
+	color: string;
+};
+
+export type AnnotationLineConnected = {
+	id: string;
+	type: "line";
+	mode: "connected";
+	fromTileId: string;
+	toTileId: string;
+	color: string;
+};
+
+export type Annotation =
+	| AnnotationRect
+	| AnnotationText
+	| AnnotationLineFree
+	| AnnotationLineConnected;
+
+export const annotations: Annotation[] = [];
+
+let idCounter = 0;
+
+let currentMode: DrawMode = "pointer";
+
+export function generateAnnotationId(): string {
+	idCounter++;
+	return `ann-${Date.now()}-${idCounter}`;
+}
+
+export function getDefaultAnnotationColor(): string {
+	const raw = getComputedStyle(document.documentElement)
+		.getPropertyValue("--muted")
+		.trim();
+	const m = raw.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+	if (m) {
+		return (
+			"#" +
+			[m[1]!, m[2]!, m[3]!]
+				.map((v) => parseInt(v, 10).toString(16).padStart(2, "0"))
+				.join("")
+		);
+	}
+	return "#888888";
+}
+
+export function addAnnotation(data: Omit<Annotation, "id">): Annotation {
+	const id = generateAnnotationId();
+	const ann = { id, ...data } as Annotation;
+	annotations.push(ann);
+	return ann;
+}
+
+export function removeAnnotation(id: string): void {
+	const idx = annotations.findIndex((a) => a.id === id);
+	if (idx !== -1) annotations.splice(idx, 1);
+}
+
+export function updateAnnotation(id: string, changes: Partial<Omit<Annotation, "id">>): Annotation | null {
+	const ann = annotations.find((a) => a.id === id);
+	if (ann) Object.assign(ann, changes);
+	return ann ?? null;
+}
+
+/**
+ * Replace a connected line with a free line in-place (no stale keys).
+ * Use this instead of updateAnnotation when converting connected→free.
+ */
+export function convertToFreeLine(
+	id: string,
+	coords: { x1: number; y1: number; x2: number; y2: number },
+): AnnotationLineFree | null {
+	const idx = annotations.findIndex((a) => a.id === id);
+	if (idx === -1) return null;
+	const existing = annotations[idx];
+	if (!existing || existing.type !== "line" || existing.mode !== "connected") return null;
+	const freeAnn: AnnotationLineFree = {
+		id: existing.id,
+		type: "line",
+		mode: "free",
+		...coords,
+		color: existing.color,
+	};
+	annotations[idx] = freeAnn;
+	return freeAnn;
+}
+
+export function getAnnotation(id: string): Annotation | null {
+	return annotations.find((a) => a.id === id) ?? null;
+}
+
+export function setDrawMode(mode: DrawMode): void {
+	currentMode = mode;
+}
+
+export function getDrawMode(): DrawMode {
+	return currentMode;
+}
+
+/**
+ * Remove connected lines that reference a deleted tile.
+ * Returns the IDs that were removed so callers can also clean up DOM.
+ */
+export function removeConnectedLinesForTile(tileId: string): string[] {
+	const toRemove = annotations
+		.filter(
+			(a): a is AnnotationLineConnected =>
+				a.type === "line" &&
+				a.mode === "connected" &&
+				(a.fromTileId === tileId || a.toTileId === tileId),
+		)
+		.map((a) => a.id);
+	for (const id of toRemove) removeAnnotation(id);
+	return toRemove;
+}
+
+/**
+ * After restoring annotations, convert any connected lines whose tile references
+ * no longer exist into free lines using the last known tile center coordinates.
+ */
+export function validateAnnotations(
+	liveTileIds: Set<string>,
+	getTileCenter: (id: string) => { x: number; y: number } | null,
+): void {
+	for (let i = 0; i < annotations.length; i++) {
+		const ann = annotations[i];
+		if (!ann || ann.type !== "line" || ann.mode !== "connected") continue;
+		const fromOk = liveTileIds.has(ann.fromTileId);
+		const toOk = liveTileIds.has(ann.toTileId);
+		if (fromOk && toOk) continue;
+		if (!fromOk && !toOk) {
+			annotations.splice(i, 1);
+			i--;
+			continue;
+		}
+		const p1 = (fromOk ? getTileCenter(ann.fromTileId) : null) ?? { x: 0, y: 0 };
+		const p2 = (toOk ? getTileCenter(ann.toTileId) : null) ?? { x: 0, y: 0 };
+		annotations[i] = {
+			id: ann.id,
+			type: "line",
+			mode: "free",
+			x1: p1.x,
+			y1: p1.y,
+			x2: p2.x,
+			y2: p2.y,
+			color: ann.color,
+		};
+	}
+}
+
+// ── Annotation selection ──────────────────────────────────────────
+
+const selectedAnnotationIds = new Set<string>();
+
+export function selectAnnotation(id: string): void {
+	selectedAnnotationIds.add(id);
+}
+
+export function clearAnnotationSelection(): void {
+	selectedAnnotationIds.clear();
+}
+
+export function isAnnotationSelected(id: string): boolean {
+	return selectedAnnotationIds.has(id);
+}
+
+export function getSelectedAnnotationIds(): Set<string> {
+	return new Set(selectedAnnotationIds);
+}
+
+export function getSelectedAnnotations(): Annotation[] {
+	return annotations.filter((a) => selectedAnnotationIds.has(a.id));
+}
+
+export function restoreAnnotations(saved: unknown[]): void {
+	annotations.length = 0;
+	if (!Array.isArray(saved)) return;
+	for (const a of saved) annotations.push({ ...(a as Annotation) });
+}
+
+export function getAnnotationsForSave(): Annotation[] {
+	return annotations.map((a) => ({ ...a }));
+}

--- a/collab-electron/src/windows/shell/src/annotation-renderer.ts
+++ b/collab-electron/src/windows/shell/src/annotation-renderer.ts
@@ -1,0 +1,1124 @@
+import type { Annotation, AnnotationLineConnected } from "./annotation-manager.js";
+import {
+	annotations,
+	addAnnotation,
+	removeAnnotation,
+	updateAnnotation,
+	convertToFreeLine,
+	getAnnotation,
+	getDefaultAnnotationColor,
+	setDrawMode,
+	getDrawMode,
+	isAnnotationSelected,
+	getSelectedAnnotations,
+} from "./annotation-manager.js";
+
+const TRASH_SVG = `<svg width="13" height="13" viewBox="0 0 256 256" fill="currentColor"><path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16H56V208a16,16,0,0,0,16,16H184a16,16,0,0,0,16-16V64h16a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm88,168H72V64H184ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"/></svg>`;
+
+type TileLike = {
+	id: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	zIndex: number;
+};
+
+type AnnotationRendererOpts = {
+	annotationLayer: HTMLElement;
+	annotationSvg: SVGSVGElement;
+	viewportState: { panX: number; panY: number; zoom: number };
+	canvasEl: HTMLElement;
+	getTiles: () => TileLike[];
+	getTileDOMs: () => Map<string, { container: HTMLElement }>;
+	onSave: () => void;
+	onModeChange: (mode: string) => void;
+	getSelectedTiles?: () => TileLike[];
+	onTileGroupDragMove?: () => void;
+};
+
+export function createAnnotationRenderer({
+	annotationLayer,
+	annotationSvg,
+	viewportState,
+	canvasEl,
+	getTiles,
+	getTileDOMs,
+	onSave,
+	onModeChange,
+	getSelectedTiles,
+	onTileGroupDragMove,
+}: AnnotationRendererOpts) {
+	const domMap = new Map<string, HTMLElement | SVGGElement>();
+
+	// ── SVG tile-mask — hides annotations where tiles sit ──────────
+	// Uses an SVG <mask>: white bg (show all) + black rects per tile (hide).
+	// Updated on every reposition so lines vanish cleanly behind tiles
+	// even when tiles have reduced opacity from the canvas opacity setting.
+
+	const svgDefs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+	annotationSvg.appendChild(svgDefs);
+
+	const tileMask = document.createElementNS("http://www.w3.org/2000/svg", "mask");
+	tileMask.id = "ann-tile-mask";
+	const tileMaskBg = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+	tileMaskBg.setAttribute("x", "-99999");
+	tileMaskBg.setAttribute("y", "-99999");
+	tileMaskBg.setAttribute("width", "199999");
+	tileMaskBg.setAttribute("height", "199999");
+	tileMaskBg.setAttribute("fill", "white");
+	tileMask.appendChild(tileMaskBg);
+	svgDefs.appendChild(tileMask);
+
+	// All annotation SVG elements live inside this masked group
+	const annotationGroup = document.createElementNS("http://www.w3.org/2000/svg", "g");
+	annotationGroup.setAttribute("mask", "url(#ann-tile-mask)");
+	annotationSvg.appendChild(annotationGroup);
+
+	function updateTileMask() {
+		// Remove previous tile rects (everything after the background rect)
+		while (tileMask.children.length > 1) {
+			tileMask.removeChild(tileMask.lastChild!);
+		}
+		for (const tile of getTiles()) {
+			const { x: sx, y: sy } = c2s(tile.x, tile.y);
+			const w = tile.width * viewportState.zoom;
+			const h = tile.height * viewportState.zoom;
+			const r = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+			r.setAttribute("x", String(sx));
+			r.setAttribute("y", String(sy));
+			r.setAttribute("width", String(w));
+			r.setAttribute("height", String(h));
+			r.setAttribute("fill", "black");
+			tileMask.appendChild(r);
+		}
+	}
+
+	// ── Coordinate helpers ──────────────────────────────────────────
+
+	function c2s(cx: number, cy: number) {
+		return {
+			x: cx * viewportState.zoom + viewportState.panX,
+			y: cy * viewportState.zoom + viewportState.panY,
+		};
+	}
+
+	function s2c(sx: number, sy: number) {
+		return {
+			x: (sx - viewportState.panX) / viewportState.zoom,
+			y: (sy - viewportState.panY) / viewportState.zoom,
+		};
+	}
+
+	// ── Positioning ─────────────────────────────────────────────────
+
+	function positionRect(g: SVGGElement, ann: import("./annotation-manager.js").AnnotationRect) {
+		const { x, y } = c2s(ann.x, ann.y);
+		const w = ann.width * viewportState.zoom;
+		const h = ann.height * viewportState.zoom;
+		for (const rect of g.querySelectorAll("rect")) {
+			rect.setAttribute("x", String(x));
+			rect.setAttribute("y", String(y));
+			rect.setAttribute("width", String(w));
+			rect.setAttribute("height", String(h));
+		}
+		g.querySelector(".ann-rect-visual")?.setAttribute("stroke", ann.color);
+	}
+
+	function positionText(el: HTMLElement, ann: import("./annotation-manager.js").AnnotationText) {
+		const { x, y } = c2s(ann.x, ann.y);
+		el.style.left = `${x}px`;
+		el.style.top = `${y}px`;
+		el.style.color = ann.color;
+		el.style.fontSize = `${ann.fontSize * viewportState.zoom}px`;
+	}
+
+	function getLineScreenCoords(ann: import("./annotation-manager.js").AnnotationLineFree | AnnotationLineConnected) {
+		if (ann.mode === "free") {
+			const p1 = c2s(ann.x1, ann.y1);
+			const p2 = c2s(ann.x2, ann.y2);
+			return { x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y };
+		}
+		// connected: derive from tile centers
+		const tileList = getTiles();
+		const from = tileList.find((t) => t.id === ann.fromTileId);
+		const to = tileList.find((t) => t.id === ann.toTileId);
+		if (!from || !to) return null;
+		const p1 = c2s(from.x + from.width / 2, from.y + from.height / 2);
+		const p2 = c2s(to.x + to.width / 2, to.y + to.height / 2);
+		return { x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y };
+	}
+
+	function positionLine(group: SVGGElement, ann: import("./annotation-manager.js").AnnotationLineFree | AnnotationLineConnected) {
+		const coords = getLineScreenCoords(ann);
+		if (!coords) return;
+		const { x1, y1, x2, y2 } = coords;
+		for (const line of group.querySelectorAll("line")) {
+			line.setAttribute("x1", String(x1));
+			line.setAttribute("y1", String(y1));
+			line.setAttribute("x2", String(x2));
+			line.setAttribute("y2", String(y2));
+		}
+	}
+
+	function positionById(id: string) {
+		const ann = getAnnotation(id);
+		const el = domMap.get(id);
+		if (!ann || !el) return;
+		if (ann.type === "rect") positionRect(el as SVGGElement, ann);
+		else if (ann.type === "text") positionText(el as HTMLElement, ann);
+		else if (ann.type === "line") positionLine(el as SVGGElement, ann);
+	}
+
+	// ── Popover ─────────────────────────────────────────────────────
+
+	let activePopover: HTMLElement | null = null;
+	let activePopoverAnnId: string | null = null;
+	let activePopoverResizeHandler: (() => void) | null = null;
+
+	function dismissPopover() {
+		if (activePopover) {
+			activePopover.remove();
+			activePopover = null;
+			activePopoverAnnId = null;
+		}
+		if (activePopoverResizeHandler) {
+			window.removeEventListener("resize", activePopoverResizeHandler);
+			activePopoverResizeHandler = null;
+		}
+	}
+
+	function showPopover(ann: Annotation, anchorEl: Element) {
+		dismissPopover();
+
+		const pop = document.createElement("div");
+		pop.className = "annotation-popover";
+		pop.style.visibility = "hidden";
+
+		// Trash
+		const trash = document.createElement("button");
+		trash.className = "ann-pop-trash";
+		trash.innerHTML = TRASH_SVG;
+		trash.title = "Delete";
+		trash.addEventListener("click", (e) => {
+			e.stopPropagation();
+			domMap.get(ann.id)?.remove();
+			domMap.delete(ann.id);
+			removeAnnotation(ann.id);
+			onSave();
+			dismissPopover();
+		});
+		pop.appendChild(trash);
+
+		// Color picker + hex input
+		const colorPicker = document.createElement("input");
+		colorPicker.type = "color";
+		colorPicker.className = "ann-pop-color-picker";
+		colorPicker.value = ann.color;
+		colorPicker.addEventListener("click", (e) => e.stopPropagation());
+
+		const hexWrap = document.createElement("div");
+		hexWrap.className = "ann-pop-hex-wrap";
+		const hashSpan = document.createElement("span");
+		hashSpan.textContent = "#";
+		const hexInput = document.createElement("input");
+		hexInput.type = "text";
+		hexInput.className = "ann-pop-hex";
+		hexInput.maxLength = 6;
+		hexInput.value = ann.color.replace("#", "");
+
+		function applyColor(val: string) {
+			updateAnnotation(ann.id, { color: val });
+			const el = domMap.get(ann.id);
+			if (el) {
+				if (ann.type === "rect") el.querySelector(".ann-rect-visual")?.setAttribute("stroke", val);
+				else if (ann.type === "text") el.style.color = val;
+				else if (ann.type === "line") el.querySelector(".ann-line-visual")?.setAttribute("stroke", val);
+			}
+			onSave();
+		}
+
+		colorPicker.addEventListener("input", () => {
+			hexInput.value = colorPicker.value.replace("#", "");
+			applyColor(colorPicker.value);
+		});
+
+		hexInput.addEventListener("input", () => {
+			const val = "#" + hexInput.value;
+			if (/^#[0-9a-fA-F]{6}$/.test(val)) {
+				colorPicker.value = val;
+				applyColor(val);
+			}
+		});
+		hexInput.addEventListener("click", (e) => e.stopPropagation());
+		hexInput.addEventListener("keydown", (e) => e.stopPropagation());
+
+		pop.appendChild(colorPicker);
+		hexWrap.appendChild(hashSpan);
+		hexWrap.appendChild(hexInput);
+		pop.appendChild(hexWrap);
+
+		// Font size buttons for text
+		if (ann.type === "text") {
+			const fontUp = document.createElement("button");
+			fontUp.className = "ann-pop-font ann-pop-font-up";
+			fontUp.textContent = "A";
+			fontUp.title = "Increase font size";
+			fontUp.addEventListener("click", (e) => {
+				e.stopPropagation();
+				const newSize = (ann.fontSize ?? 16) + 2;
+				updateAnnotation(ann.id, { fontSize: newSize });
+				const el = domMap.get(ann.id);
+				if (el) el.style.fontSize = `${newSize * viewportState.zoom}px`;
+				onSave();
+			});
+
+			const fontDown = document.createElement("button");
+			fontDown.className = "ann-pop-font ann-pop-font-down";
+			fontDown.textContent = "a";
+			fontDown.title = "Decrease font size";
+			fontDown.addEventListener("click", (e) => {
+				e.stopPropagation();
+				const newSize = Math.max(8, (ann.fontSize ?? 16) - 2);
+				updateAnnotation(ann.id, { fontSize: newSize });
+				const el = domMap.get(ann.id);
+				if (el) el.style.fontSize = `${newSize * viewportState.zoom}px`;
+				onSave();
+			});
+
+			pop.appendChild(fontUp);
+			pop.appendChild(fontDown);
+		}
+
+		document.body.appendChild(pop);
+		activePopover = pop;
+		activePopoverAnnId = ann.id;
+
+		// Position above anchor (clamped to viewport).
+		// Use rAF to ensure layout is complete before reading getBoundingClientRect.
+		function positionPopover() {
+			const ar = anchorEl.getBoundingClientRect();
+			const pr = pop.getBoundingClientRect();
+			let left = ar.left + ar.width / 2 - pr.width / 2;
+			let top = ar.top - pr.height - 8;
+			left = Math.max(8, Math.min(left, window.innerWidth - pr.width - 8));
+			if (top < 8) top = ar.bottom + 8;
+			pop.style.left = `${left}px`;
+			pop.style.top = `${top}px`;
+			pop.style.visibility = "visible";
+		}
+
+		requestAnimationFrame(positionPopover);
+		activePopoverResizeHandler = positionPopover;
+		window.addEventListener("resize", positionPopover);
+	}
+
+	// ── Drag on existing annotations ────────────────────────────────
+
+	// Guard against accumulating multiple simultaneous drag listener sets
+	// (e.g. if mouseup was missed because the window lost focus mid-drag).
+	let isDragging = false;
+
+	function attachAnnotationDrag(el: HTMLElement | SVGElement, ann: Annotation) {
+		el.addEventListener("mousedown", (rawE) => {
+			const e = rawE as MouseEvent;
+			if (e.button !== 0) return;
+			if (isDragging) return;
+			isDragging = true;
+			e.stopPropagation();
+
+			const startClientX = e.clientX;
+			const startClientY = e.clientY;
+			let dragged = false;
+
+			// Determine if this is a group drag (annotation is part of a multi-selection)
+			const selectedAnns = getSelectedAnnotations();
+			const isGroupDrag = selectedAnns.length > 1 && isAnnotationSelected(ann.id);
+
+			// Snapshot start canvas coords for all group members (or just this annotation)
+			const dragGroup = isGroupDrag ? selectedAnns : [ann];
+
+			// Snapshot selected tile positions for cross-system group drag
+			const annIsSelected = isAnnotationSelected(ann.id);
+			const tileDragGroup = annIsSelected && getSelectedTiles
+				? (getSelectedTiles() ?? []).map((t) => ({ tile: t, startX: t.x, startY: t.y }))
+				: [];
+
+			type Snap = {
+				ann: Annotation;
+				connected?: boolean;
+				x?: number;
+				y?: number;
+				x1?: number;
+				y1?: number;
+				x2?: number;
+				y2?: number;
+			};
+			const snapshots: Snap[] = dragGroup.map((a) => {
+				if (a.type === "line") {
+					if (a.mode === "free") {
+						return { ann: a, x1: a.x1, y1: a.y1, x2: a.x2, y2: a.y2 };
+					}
+					// connected lines: snapshot tile-center screen coords, converted to free on drag
+					return { ann: a, connected: true };
+				}
+				return { ann: a, x: a.x, y: a.y };
+			});
+
+			function onMove(ev: MouseEvent) {
+				const dx = ev.clientX - startClientX;
+				const dy = ev.clientY - startClientY;
+
+				if (!dragged && Math.hypot(dx, dy) > 4) {
+					dragged = true;
+					dismissPopover();
+
+					// Convert connected lines to free on first drag —
+					// but only when dragging the line individually (not as part of a group
+					// selection, where tiles move too and the line should stay anchored).
+					if (!isGroupDrag) {
+						for (const snap of snapshots) {
+							if (snap.connected) {
+								const coords = getLineScreenCoords(snap.ann as AnnotationLineConnected);
+								if (coords) {
+									const c1 = s2c(coords.x1, coords.y1);
+									const c2 = s2c(coords.x2, coords.y2);
+									// Use convertToFreeLine to replace the object in-place,
+									// avoiding stale fromTileId/toTileId keys in serialization.
+									const freed = convertToFreeLine(snap.ann.id, {
+										x1: c1.x, y1: c1.y,
+										x2: c2.x, y2: c2.y,
+									});
+									if (freed) {
+										snap.x1 = freed.x1;
+										snap.y1 = freed.y1;
+										snap.x2 = freed.x2;
+										snap.y2 = freed.y2;
+										snap.connected = false;
+									}
+								}
+							}
+						}
+					}
+				}
+				if (!dragged) return;
+
+				const dcx = dx / viewportState.zoom;
+				const dcy = dy / viewportState.zoom;
+
+				for (const snap of snapshots) {
+					const a = snap.ann;
+					// Skip connected lines in a group drag — they track their tiles via onTileMoved
+					if (snap.connected) continue;
+					if (a.type === "rect" || a.type === "text") {
+						updateAnnotation(a.id, { x: snap.x! + dcx, y: snap.y! + dcy });
+					} else if (a.type === "line") {
+						updateAnnotation(a.id, {
+							x1: snap.x1! + dcx, y1: snap.y1! + dcy,
+							x2: snap.x2! + dcx, y2: snap.y2! + dcy,
+						});
+					}
+					positionById(a.id);
+				}
+
+				// Also move selected tiles
+				if (tileDragGroup.length > 0) {
+					for (const { tile, startX, startY } of tileDragGroup) {
+						tile.x = startX + dcx;
+						tile.y = startY + dcy;
+					}
+					onTileGroupDragMove?.();
+				}
+			}
+
+			function cleanup() {
+				document.removeEventListener("mousemove", onMove);
+				document.removeEventListener("mouseup", onUp);
+				window.removeEventListener("blur", cleanup);
+				isDragging = false;
+			}
+
+			function onUp() {
+				cleanup();
+				if (dragged) {
+					onSave();
+				} else {
+					showPopover(ann, el as HTMLElement);
+				}
+			}
+
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+			window.addEventListener("blur", cleanup);
+		});
+	}
+
+	// ── DOM creation ────────────────────────────────────────────────
+
+	function createRectEl(ann: import("./annotation-manager.js").AnnotationRect) {
+		const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+		g.dataset.annId = ann.id;
+
+		// Wide invisible hit target on the stroke only — interior is transparent to events
+		const hit = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+		hit.setAttribute("fill", "none");
+		hit.setAttribute("stroke", "transparent");
+		hit.setAttribute("stroke-width", "10");
+		hit.setAttribute("rx", "8");
+		hit.style.pointerEvents = "stroke";
+		hit.style.cursor = "move";
+
+		// Visible border
+		const visual = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+		visual.classList.add("ann-rect-visual");
+		visual.setAttribute("fill", "none");
+		visual.setAttribute("stroke", ann.color);
+		visual.setAttribute("stroke-width", "2");
+		visual.setAttribute("rx", "8");
+		visual.style.pointerEvents = "none";
+
+		g.appendChild(hit);
+		g.appendChild(visual);
+		annotationGroup.appendChild(g);
+		positionRect(g, ann);
+		attachAnnotationDrag(hit, ann);
+		return g;
+	}
+
+	function createTextEl(ann: import("./annotation-manager.js").AnnotationText) {
+		const el = document.createElement("div");
+		el.className = "annotation-text";
+		el.dataset.annId = ann.id;
+		el.textContent = ann.content;
+		positionText(el, ann);
+		attachAnnotationDrag(el, ann);
+
+		el.addEventListener("dblclick", (e) => {
+			e.stopPropagation();
+			dismissPopover();
+
+			// Hide the live label and show an editor in its place
+			el.style.visibility = "hidden";
+
+			const editor = document.createElement("div");
+			editor.className = "annotation-text-editor";
+			editor.contentEditable = "true";
+			editor.style.left = el.style.left;
+			editor.style.top = el.style.top;
+			editor.style.color = ann.color;
+			editor.style.fontSize = el.style.fontSize;
+			editor.textContent = ann.content;
+			annotationLayer.appendChild(editor);
+
+			// Select all text so the user can type over it or position cursor
+			requestAnimationFrame(() => {
+				editor.focus();
+				const range = document.createRange();
+				range.selectNodeContents(editor);
+				const sel = window.getSelection();
+				sel?.removeAllRanges();
+				sel?.addRange(range);
+			});
+
+			let committed = false;
+
+			function commit() {
+				if (committed) return;
+				committed = true;
+				const content = editor.textContent?.trim() ?? "";
+				editor.remove();
+				if (content) {
+					updateAnnotation(ann.id, { content });
+					el.textContent = content;
+					el.style.visibility = "";
+				} else {
+					// User cleared the text — remove the annotation entirely
+					el.remove();
+					domMap.delete(ann.id);
+					removeAnnotation(ann.id);
+				}
+				onSave();
+			}
+
+			editor.addEventListener("blur", commit, { once: true });
+			editor.addEventListener("keydown", (e) => {
+				e.stopPropagation();
+				if (e.key === "Escape" && !committed) {
+					committed = true;
+					editor.removeEventListener("blur", commit);
+					editor.remove();
+					el.style.visibility = "";
+				}
+			});
+		});
+
+		annotationLayer.appendChild(el);
+		return el;
+	}
+
+	function createLineGroup(ann: import("./annotation-manager.js").AnnotationLineFree | AnnotationLineConnected) {
+		const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+		g.dataset.annId = ann.id;
+
+		// Wide invisible hit target
+		const hit = document.createElementNS(
+			"http://www.w3.org/2000/svg",
+			"line",
+		);
+		hit.classList.add("ann-line-hit");
+		hit.setAttribute("stroke", "transparent");
+		hit.setAttribute("stroke-width", "12");
+		hit.setAttribute("stroke-linecap", "round");
+		hit.style.cursor = "move";
+		hit.style.pointerEvents = "stroke";
+
+		// Visible line
+		const visual = document.createElementNS(
+			"http://www.w3.org/2000/svg",
+			"line",
+		);
+		visual.classList.add("ann-line-visual");
+		visual.setAttribute("stroke", ann.color);
+		visual.setAttribute("stroke-width", "2");
+		visual.setAttribute("stroke-linecap", "round");
+		visual.style.pointerEvents = "none";
+
+		g.appendChild(hit);
+		g.appendChild(visual);
+		annotationGroup.appendChild(g);
+		positionLine(g, ann);
+		attachAnnotationDrag(hit, ann);
+		return g;
+	}
+
+	function renderAnnotation(ann: Annotation) {
+		let el;
+		if (ann.type === "rect") el = createRectEl(ann);
+		else if (ann.type === "text") el = createTextEl(ann);
+		else if (ann.type === "line") el = createLineGroup(ann);
+		else return;
+		domMap.set(ann.id, el);
+	}
+
+	// ── Draw interactions ────────────────────────────────────────────
+
+	// Preview elements
+	let previewEl: HTMLElement | SVGGElement | null = null; // rect div or SVG g for line
+	let drawStartClientX = 0;
+	let drawStartClientY = 0;
+	let drawStartCX = 0;
+	let drawStartCY = 0;
+
+	// Line connected-mode state
+	let linePhase1: { fromTileId: string; previewLine: SVGGElement } | null = null;
+
+	function clearPreview() {
+		if (previewEl) {
+			previewEl.remove();
+			previewEl = null;
+		}
+	}
+
+	function cancelLinePhase1() {
+		if (linePhase1?.previewLine) linePhase1.previewLine.remove();
+		clearAllLineHighlights();
+		linePhase1 = null;
+	}
+
+	/** Hit test canvas coords against tiles. */
+	function tileAtCanvasPoint(cx: number, cy: number) {
+		const tileList = [...getTiles()].sort((a, b) => b.zIndex - a.zIndex);
+		for (const t of tileList) {
+			if (
+				cx >= t.x &&
+				cx < t.x + t.width &&
+				cy >= t.y &&
+				cy < t.y + t.height
+			) {
+				return t;
+			}
+		}
+		return null;
+	}
+
+	/** Set highlight on a tile container. */
+	function setTileHighlight(tileId: string, active: boolean) {
+		const dom = getTileDOMs().get(tileId);
+		if (dom) {
+			dom.container.classList.toggle("annotation-line-target", active);
+		}
+	}
+
+	let lineHoverTileId: string | null = null;
+
+	function setLineHover(tileId: string | null) {
+		if (lineHoverTileId === tileId) return;
+		if (lineHoverTileId) {
+			getTileDOMs().get(lineHoverTileId)?.container.classList.remove("annotation-line-hover");
+		}
+		lineHoverTileId = tileId;
+		if (tileId) {
+			getTileDOMs().get(tileId)?.container.classList.add("annotation-line-hover");
+		}
+	}
+
+	function clearAllLineHighlights() {
+		for (const [, dom] of getTileDOMs()) {
+			dom.container.classList.remove("annotation-line-hover", "annotation-line-source", "annotation-line-target");
+		}
+		lineHoverTileId = null;
+	}
+
+	// Hover highlight in draw-line mode — works both before and after first tile is selected
+	canvasEl.addEventListener("mousemove", (e) => {
+		if (getDrawMode() !== "draw-line") return;
+		const rect = canvasEl.getBoundingClientRect();
+		const { x: cx, y: cy } = s2c(e.clientX - rect.left, e.clientY - rect.top);
+		const tile = tileAtCanvasPoint(cx, cy);
+		const hoverId = (tile && tile.id !== linePhase1?.fromTileId) ? tile.id : null;
+		setLineHover(hoverId);
+	});
+
+	// Canvas mousedown — handle draw modes
+	canvasEl.addEventListener(
+		"mousedown",
+		(e) => {
+			const mode = getDrawMode();
+			if (mode === "pointer") return;
+			if (e.button !== 0) return;
+
+			// Block marquee and panning from firing
+			e.stopImmediatePropagation();
+
+			const rect = canvasEl.getBoundingClientRect();
+			const sx = e.clientX - rect.left;
+			const sy = e.clientY - rect.top;
+			const { x: cx, y: cy } = s2c(sx, sy);
+
+			if (mode === "draw-rect") {
+				drawStartClientX = e.clientX;
+				drawStartClientY = e.clientY;
+				drawStartCX = cx;
+				drawStartCY = cy;
+
+				previewEl = document.createElement("div");
+				previewEl.className = "annotation-preview-rect";
+				previewEl.style.left = `${sx}px`;
+				previewEl.style.top = `${sy}px`;
+				previewEl.style.width = "0";
+				previewEl.style.height = "0";
+				annotationLayer.appendChild(previewEl);
+
+				function onRectMove(ev: MouseEvent) {
+					const cRect = canvasEl.getBoundingClientRect();
+					const curSX = ev.clientX - cRect.left;
+					const curSY = ev.clientY - cRect.top;
+					const left = Math.min(
+						drawStartCX * viewportState.zoom + viewportState.panX,
+						curSX,
+					);
+					const top = Math.min(
+						drawStartCY * viewportState.zoom + viewportState.panY,
+						curSY,
+					);
+					const w = Math.abs(
+						curSX -
+							(drawStartCX * viewportState.zoom + viewportState.panX),
+					);
+					const h = Math.abs(
+						curSY -
+							(drawStartCY * viewportState.zoom + viewportState.panY),
+					);
+					if (previewEl) {
+						previewEl.style.left = `${left}px`;
+						previewEl.style.top = `${top}px`;
+						previewEl.style.width = `${w}px`;
+						previewEl.style.height = `${h}px`;
+					}
+				}
+
+				function onRectUp(ev: MouseEvent) {
+					document.removeEventListener("mousemove", onRectMove);
+					document.removeEventListener("mouseup", onRectUp);
+					clearPreview();
+
+					const cRect = canvasEl.getBoundingClientRect();
+					const curSX = ev.clientX - cRect.left;
+					const curSY = ev.clientY - cRect.top;
+					const { x: curCX, y: curCY } = s2c(curSX, curSY);
+
+					const w = Math.abs(curCX - drawStartCX);
+					const h = Math.abs(curCY - drawStartCY);
+					if (w < 10 || h < 10) {
+						// Too small — cancel
+					} else {
+						const color = getDefaultAnnotationColor();
+						const ann = addAnnotation({
+							type: "rect",
+							x: Math.min(drawStartCX, curCX),
+							y: Math.min(drawStartCY, curCY),
+							width: w,
+							height: h,
+							color,
+						});
+						renderAnnotation(ann);
+						onSave();
+					}
+					activateMode("pointer");
+				}
+
+				document.addEventListener("mousemove", onRectMove);
+				document.addEventListener("mouseup", onRectUp);
+			} else if (mode === "draw-text") {
+				// Commit text immediately at click
+				activateMode("pointer");
+				spawnTextEditor(cx, cy);
+			} else if (mode === "draw-line") {
+				// Check if we're in phase 1 (waiting for second tile)
+				if (linePhase1) {
+					const targetTile = tileAtCanvasPoint(cx, cy);
+					if (targetTile && targetTile.id !== linePhase1.fromTileId) {
+						// Clicked a different tile → connected line
+						const fromId = linePhase1.fromTileId;
+						cancelLinePhase1();
+						const color = getDefaultAnnotationColor();
+						const ann = addAnnotation({
+							type: "line",
+							mode: "connected",
+							fromTileId: fromId,
+							toTileId: targetTile.id,
+							color,
+						});
+						renderAnnotation(ann);
+						onSave();
+					} else {
+						// Clicked canvas or same tile → free line from source center to here
+						const phase1FromId = linePhase1!.fromTileId;
+						const fromTile = getTiles().find((t) => t.id === phase1FromId);
+						cancelLinePhase1();
+						if (fromTile) {
+							const color = getDefaultAnnotationColor();
+							const ann = addAnnotation({
+								type: "line",
+								mode: "free",
+								x1: fromTile.x + fromTile.width / 2,
+								y1: fromTile.y + fromTile.height / 2,
+								x2: cx,
+								y2: cy,
+								color,
+							});
+							renderAnnotation(ann);
+							onSave();
+						}
+					}
+					activateMode("pointer");
+					return;
+				}
+
+				const tile = tileAtCanvasPoint(cx, cy);
+
+				if (tile) {
+					// Start connected-line phase 1 (detect click vs drag on mouseup)
+					drawStartClientX = e.clientX;
+					drawStartClientY = e.clientY;
+
+					// Create a preview SVG line from tile center to cursor
+					const g = document.createElementNS(
+						"http://www.w3.org/2000/svg",
+						"g",
+					);
+					const pl = document.createElementNS(
+						"http://www.w3.org/2000/svg",
+						"line",
+					);
+					pl.setAttribute("stroke", getDefaultAnnotationColor());
+					pl.setAttribute("stroke-width", "2");
+					pl.setAttribute("stroke-linecap", "round");
+					pl.setAttribute("stroke-dasharray", "6 4");
+					pl.style.pointerEvents = "none";
+					g.appendChild(pl);
+					annotationSvg.appendChild(g);
+
+					const tileCenterS = c2s(
+						tile.x + tile.width / 2,
+						tile.y + tile.height / 2,
+					);
+					pl.setAttribute("x1", String(tileCenterS.x));
+					pl.setAttribute("y1", String(tileCenterS.y));
+					pl.setAttribute("x2", String(tileCenterS.x));
+					pl.setAttribute("y2", String(tileCenterS.y));
+
+					linePhase1 = { fromTileId: tile.id, previewLine: g };
+					setLineHover(null);
+					// Green border on the selected source tile
+					getTileDOMs().get(tile.id)?.container.classList.add("annotation-line-source");
+
+					let lineDragged = false;
+
+					function onLineTileMove(ev: MouseEvent) {
+						const dist = Math.hypot(
+							ev.clientX - drawStartClientX,
+							ev.clientY - drawStartClientY,
+						);
+						if (dist > 4) lineDragged = true;
+
+						// Update preview line end
+						const cRect = canvasEl.getBoundingClientRect();
+						const curSX = ev.clientX - cRect.left;
+						const curSY = ev.clientY - cRect.top;
+						pl.setAttribute("x2", String(curSX));
+						pl.setAttribute("y2", String(curSY));
+
+					}
+
+					function onLineTileUp(ev: MouseEvent) {
+						document.removeEventListener("mousemove", onLineTileMove);
+						document.removeEventListener("mouseup", onLineTileUp);
+
+						const cRect = canvasEl.getBoundingClientRect();
+						const curSX = ev.clientX - cRect.left;
+						const curSY = ev.clientY - cRect.top;
+						const { x: curCX, y: curCY } = s2c(curSX, curSY);
+
+						if (lineDragged) {
+							// Free line drag from tile center to release point
+							cancelLinePhase1();
+							const color = getDefaultAnnotationColor();
+							const ann = addAnnotation({
+								type: "line",
+								mode: "free",
+								x1: tile!.x + tile!.width / 2,
+								y1: tile!.y + tile!.height / 2,
+								x2: curCX,
+								y2: curCY,
+								color,
+							});
+							renderAnnotation(ann);
+							onSave();
+							activateMode("pointer");
+						} else {
+							// Click: stay in phase 1, waiting for second tile
+							// (phase 1 active state is handled by subsequent mousedown)
+						}
+					}
+
+					document.addEventListener("mousemove", onLineTileMove);
+					document.addEventListener("mouseup", onLineTileUp);
+				} else {
+					// Free line drag on empty canvas
+					drawStartClientX = e.clientX;
+					drawStartClientY = e.clientY;
+					drawStartCX = cx;
+					drawStartCY = cy;
+
+					const g = document.createElementNS(
+						"http://www.w3.org/2000/svg",
+						"g",
+					);
+					const pl = document.createElementNS(
+						"http://www.w3.org/2000/svg",
+						"line",
+					);
+					pl.setAttribute("stroke", getDefaultAnnotationColor());
+					pl.setAttribute("stroke-width", "2");
+					pl.setAttribute("stroke-linecap", "round");
+					pl.setAttribute("stroke-dasharray", "6 4");
+					pl.style.pointerEvents = "none";
+					const startS = c2s(cx, cy);
+					pl.setAttribute("x1", String(startS.x));
+					pl.setAttribute("y1", String(startS.y));
+					pl.setAttribute("x2", String(startS.x));
+					pl.setAttribute("y2", String(startS.y));
+					g.appendChild(pl);
+					annotationSvg.appendChild(g);
+					previewEl = g;
+
+					function onFreeLineMove(ev: MouseEvent) {
+						const cRect = canvasEl.getBoundingClientRect();
+						const curSX = ev.clientX - cRect.left;
+						const curSY = ev.clientY - cRect.top;
+						pl.setAttribute("x2", String(curSX));
+						pl.setAttribute("y2", String(curSY));
+					}
+
+					function onFreeLineUp(ev: MouseEvent) {
+						document.removeEventListener("mousemove", onFreeLineMove);
+						document.removeEventListener("mouseup", onFreeLineUp);
+						clearPreview();
+
+						const cRect = canvasEl.getBoundingClientRect();
+						const curSX = ev.clientX - cRect.left;
+						const curSY = ev.clientY - cRect.top;
+						const { x: curCX, y: curCY } = s2c(curSX, curSY);
+
+						const dist = Math.hypot(
+							curCX - drawStartCX,
+							curCY - drawStartCY,
+						);
+						if (dist > 5) {
+							const color = getDefaultAnnotationColor();
+							const ann = addAnnotation({
+								type: "line",
+								mode: "free",
+								x1: drawStartCX,
+								y1: drawStartCY,
+								x2: curCX,
+								y2: curCY,
+								color,
+							});
+							renderAnnotation(ann);
+							onSave();
+						}
+						activateMode("pointer");
+					}
+
+					document.addEventListener("mousemove", onFreeLineMove);
+					document.addEventListener("mouseup", onFreeLineUp);
+				}
+			}
+		},
+		true, // capture phase — fires before marquee listener
+	);
+
+	// Escape cancels draw mode / line phase 1
+	// Backspace/Delete removes the annotation whose popover is open
+	window.addEventListener("keydown", (e) => {
+		if (e.key === "Escape") {
+			if (getDrawMode() !== "pointer") {
+				cancelLinePhase1();
+				clearPreview();
+				activateMode("pointer");
+			} else if (linePhase1) {
+				cancelLinePhase1();
+			}
+			return;
+		}
+
+		if ((e.key === "Backspace" || e.key === "Delete") && activePopoverAnnId) {
+			const id = activePopoverAnnId;
+			domMap.get(id)?.remove();
+			domMap.delete(id);
+			removeAnnotation(id);
+			onSave();
+			dismissPopover();
+		}
+	});
+
+	// Dismiss popover on outside click
+	document.addEventListener("mousedown", (e) => {
+		if (
+			activePopover &&
+			!activePopover.contains(e.target as Node | null)
+		) {
+			dismissPopover();
+		}
+	});
+
+	// ── Text editor ─────────────────────────────────────────────────
+
+	function spawnTextEditor(cx: number, cy: number) {
+		const color = getDefaultAnnotationColor();
+		const fontSize = 16;
+		const { x: sx, y: sy } = c2s(cx, cy);
+
+		const editor = document.createElement("div");
+		editor.className = "annotation-text-editor";
+		editor.contentEditable = "true";
+		editor.style.left = `${sx}px`;
+		editor.style.top = `${sy}px`;
+		editor.style.color = color;
+		editor.style.fontSize = `${fontSize * viewportState.zoom}px`;
+		annotationLayer.appendChild(editor);
+
+		requestAnimationFrame(() => editor.focus());
+
+		function commit() {
+			const content = editor.textContent?.trim() ?? "";
+			editor.remove();
+			if (content) {
+				const ann = addAnnotation({
+					type: "text",
+					x: cx,
+					y: cy,
+					content,
+					fontSize,
+					color,
+				});
+				renderAnnotation(ann);
+				onSave();
+			}
+		}
+
+		editor.addEventListener("blur", commit, { once: true });
+		editor.addEventListener("keydown", (e) => {
+			e.stopPropagation();
+			if (e.key === "Escape") {
+				editor.removeEventListener("blur", commit);
+				editor.remove();
+			}
+		});
+	}
+
+	// ── Mode management ──────────────────────────────────────────────
+
+	function activateMode(mode: string) {
+		if (mode !== "pointer") dismissPopover();
+		if (linePhase1 && mode !== "draw-line") {
+			cancelLinePhase1();
+		}
+		if (mode !== "draw-line") {
+			clearAllLineHighlights();
+		}
+		setDrawMode(mode as import("./annotation-manager.js").DrawMode);
+		onModeChange(mode);
+	}
+
+	// ── Public API ───────────────────────────────────────────────────
+
+	function repositionAll() {
+		for (const ann of annotations) positionById(ann.id);
+		updateTileMask();
+	}
+
+	function renderAll() {
+		for (const ann of annotations) {
+			if (!domMap.has(ann.id)) renderAnnotation(ann);
+		}
+		updateTileMask();
+	}
+
+	/** Call when a tile has moved — re-positions connected lines. */
+	function onTileMoved() {
+		for (const ann of annotations) {
+			if (ann.type === "line" && ann.mode === "connected") {
+				const g = domMap.get(ann.id);
+				if (g) positionLine(g as SVGGElement, ann);
+			}
+		}
+		updateTileMask();
+	}
+
+	/** Remove DOM for a deleted annotation (called by tile-manager on tile removal). */
+	function removeAnnotationDOM(id: string) {
+		domMap.get(id)?.remove();
+		domMap.delete(id);
+	}
+
+	/** Sync the .annotation-selected class on all annotation DOM elements. */
+	function syncSelectionVisuals() {
+		for (const ann of annotations) {
+			const el = domMap.get(ann.id);
+			if (!el) continue;
+			el.classList.toggle("annotation-selected", isAnnotationSelected(ann.id));
+		}
+	}
+
+	return {
+		repositionAll,
+		renderAll,
+		onTileMoved,
+		removeAnnotationDOM,
+		activateMode,
+		syncSelectionVisuals,
+	};
+}

--- a/collab-electron/src/windows/shell/src/canvas-state.js
+++ b/collab-electron/src/windows/shell/src/canvas-state.js
@@ -21,6 +21,7 @@
 /** @type {Tile[]} */
 export const tiles = [];
 
+
 let nextZIndex = 1;
 
 const DEFAULT_TILE_SIZES = {

--- a/collab-electron/src/windows/shell/src/canvas-state.js
+++ b/collab-electron/src/windows/shell/src/canvas-state.js
@@ -21,7 +21,6 @@
 /** @type {Tile[]} */
 export const tiles = [];
 
-
 let nextZIndex = 1;
 
 const DEFAULT_TILE_SIZES = {

--- a/collab-electron/src/windows/shell/src/renderer.js
+++ b/collab-electron/src/windows/shell/src/renderer.js
@@ -4,6 +4,22 @@ import {
 	tiles, getTile, defaultSize, inferTileType, tileAtPoint,
 	selectTile, clearSelection, getSelectedTiles,
 } from "./canvas-state.js";
+import {
+	getDrawMode,
+	setDrawMode,
+	removeConnectedLinesForTile,
+	restoreAnnotations,
+	validateAnnotations,
+	getAnnotationsForSave,
+	annotations,
+	selectAnnotation,
+	clearAnnotationSelection,
+	getSelectedAnnotations,
+	removeAnnotation,
+	getAnnotation,
+	updateAnnotation,
+} from "./annotation-manager.js";
+import { createAnnotationRenderer } from "./annotation-renderer.js";
 import { attachMarquee } from "./tile-interactions.js";
 import { initDarkMode, applyCanvasOpacity } from "./dark-mode.js";
 import { createWebview, isFocusSearchShortcut } from "./webview-factory.js";
@@ -509,13 +525,19 @@ async function init() {
 		onReposition: () => { viewport.redrawGrid(); minimapRef?.update(); },
 		onSaveDebounced(state) {
 			window.shellApi.canvasSaveState(
-				toCenterPointState(state),
+				toCenterPointState({
+					...state,
+					annotations: getAnnotationsForSave(),
+				}),
 			);
 			syncTileList();
 		},
 		onSaveImmediate(state) {
 			window.shellApi.canvasSaveState(
-				toCenterPointState(state),
+				toCenterPointState({
+					...state,
+					annotations: getAnnotationsForSave(),
+				}),
 			);
 			syncTileList();
 		},
@@ -547,6 +569,36 @@ async function init() {
 		},
 		onTileDblClick(tile) {
 			edgeIndicators.panToTile(tile);
+		},
+		onAfterTilesMoved() {
+			annotationRenderer?.onTileMoved();
+		},
+		onTileRemoved(tileId) {
+			const removedIds = removeConnectedLinesForTile(tileId);
+			for (const id of removedIds) annotationRenderer?.removeAnnotationDOM(id);
+		},
+		onGroupDragStart() {
+			// Snapshot selected annotation positions at the start of a tile group drag
+			const selected = getSelectedAnnotations();
+			annGroupDragSnapshot = selected.map((a) => ({ ...a }));
+		},
+		onGroupDragMove(dcx, dcy) {
+			if (!annGroupDragSnapshot || annGroupDragSnapshot.length === 0) return;
+			for (const snap of annGroupDragSnapshot) {
+				if (snap.type === "rect" || snap.type === "text") {
+					updateAnnotation(snap.id, { x: snap.x + dcx, y: snap.y + dcy });
+				} else if (snap.type === "line" && snap.mode === "free") {
+					updateAnnotation(snap.id, {
+						x1: snap.x1 + dcx, y1: snap.y1 + dcy,
+						x2: snap.x2 + dcx, y2: snap.y2 + dcy,
+					});
+				}
+				// connected lines track tiles automatically via onTileMoved — skip
+			}
+			annotationRenderer?.repositionAll();
+		},
+		onGroupDragEnd() {
+			annGroupDragSnapshot = null;
 		},
 	});
 
@@ -580,10 +632,97 @@ async function init() {
 		tileManager, viewportState, viewport, edgeIndicators,
 	});
 
+	// -- Annotation renderer --
+
+	/** @type {ReturnType<import('./annotation-renderer.js').createAnnotationRenderer> | null} */
+	let annotationRenderer = null;
+	let annGroupDragSnapshot = null;
+
+	const drawBtn = document.getElementById("draw-btn");
+	const drawPopover = document.getElementById("draw-popover");
+
+	annotationRenderer = createAnnotationRenderer({
+		annotationLayer: document.getElementById("annotation-layer"),
+		annotationSvg: document.getElementById("annotation-svg"),
+		viewportState,
+		canvasEl,
+		getTiles: () => tiles,
+		getTileDOMs: () => tileManager.getTileDOMs(),
+		onSave: () => tileManager.saveCanvasDebounced(),
+		getSelectedTiles: () => getSelectedTiles(),
+		onTileGroupDragMove: () => tileManager.repositionAllTiles(),
+		onModeChange(mode) {
+			setDrawMode(mode);
+			const panelViewer = document.getElementById("panel-viewer");
+			panelViewer.classList.remove("draw-rect", "draw-text", "draw-line");
+			if (mode !== "pointer") {
+				panelViewer.classList.add(mode);
+				drawBtn.classList.add("active");
+			} else {
+				drawBtn.classList.remove("active");
+			}
+		},
+	});
+
+	// Draw button toggles popover
+	let drawPopoverResizeHandler = null;
+
+	function positionDrawPopover() {
+		const br = drawBtn.getBoundingClientRect();
+		const pr = drawPopover.getBoundingClientRect();
+		drawPopover.style.left = `${Math.max(8, br.right - pr.width)}px`;
+		drawPopover.style.top = `${br.bottom + 4}px`;
+	}
+
+	function openDrawPopover() {
+		drawPopover.classList.remove("hidden");
+		positionDrawPopover();
+		drawPopoverResizeHandler = positionDrawPopover;
+		window.addEventListener("resize", drawPopoverResizeHandler);
+	}
+
+	function closeDrawPopover() {
+		drawPopover.classList.add("hidden");
+		if (drawPopoverResizeHandler) {
+			window.removeEventListener("resize", drawPopoverResizeHandler);
+			drawPopoverResizeHandler = null;
+		}
+	}
+
+	drawBtn.addEventListener("click", (e) => {
+		e.stopPropagation();
+		if (drawPopover.classList.contains("hidden")) {
+			openDrawPopover();
+		} else {
+			closeDrawPopover();
+		}
+	});
+
+	// Tool buttons in popover
+	for (const btn of drawPopover.querySelectorAll(".draw-tool-btn")) {
+		btn.addEventListener("click", (e) => {
+			e.stopPropagation();
+			closeDrawPopover();
+			const tool = btn.dataset.tool;
+			const mode = `draw-${tool}`;
+			annotationRenderer.activateMode(mode);
+		});
+	}
+
+	// Close popover on outside click
+	document.addEventListener("click", (e) => {
+		if (!drawPopover.classList.contains("hidden") &&
+			!drawBtn.contains(e.target) &&
+			!drawPopover.contains(e.target)) {
+			closeDrawPopover();
+		}
+	});
+
 	// -- Wire viewport updates --
 
 	viewport.init(viewportState, () => {
 		tileManager.repositionAllTiles();
+		annotationRenderer?.repositionAll();
 		edgeIndicators.update();
 		minimap.update();
 		tileManager.saveCanvasDebounced();
@@ -749,7 +888,8 @@ async function init() {
 	canvasEl.addEventListener("dblclick", (e) => {
 		if (
 			spaceHeld || isPanning ||
-			Date.now() < suppressCanvasDblClickUntil
+			Date.now() < suppressCanvasDblClickUntil ||
+			getDrawMode() !== "pointer"
 		) return;
 		if (
 			e.target !== canvasEl && e.target !== gridCanvas &&
@@ -779,6 +919,7 @@ async function init() {
 			e.target !== canvasEl && e.target !== gridCanvas &&
 			e.target !== tileLayer
 		) return;
+		if (getDrawMode() !== "pointer") return;
 		e.preventDefault();
 
 		const rect = canvasEl.getBoundingClientRect();
@@ -819,6 +960,25 @@ async function init() {
 
 	// -- Marquee selection --
 
+	function annotationHitsRect(ann, { left, top, right, bottom }, tileCenterMap) {
+		const pointIn = (x, y) => x >= left && x <= right && y >= top && y <= bottom;
+		if (ann.type === "rect") {
+			return ann.x < right && ann.x + ann.width > left &&
+				ann.y < bottom && ann.y + ann.height > top;
+		}
+		if (ann.type === "text") return pointIn(ann.x, ann.y);
+		if (ann.type === "line") {
+			if (ann.mode === "free") {
+				return pointIn(ann.x1, ann.y1) || pointIn(ann.x2, ann.y2);
+			}
+			// connected — O(1) lookup via pre-built map
+			const from = tileCenterMap.get(ann.fromTileId);
+			const to = tileCenterMap.get(ann.toTileId);
+			return (from && pointIn(from.x, from.y)) || (to && pointIn(to.x, to.y));
+		}
+		return false;
+	}
+
 	attachMarquee(canvasEl, {
 		viewport: {
 			get panX() { return viewportState.panX; },
@@ -826,6 +986,7 @@ async function init() {
 			get zoom() { return viewportState.zoom; },
 		},
 		tiles: () => tiles,
+		isBlocked: () => getDrawMode() !== "pointer",
 		onSelectionChange: (ids) => {
 			if (shiftHeld) {
 				for (const id of ids) selectTile(id);
@@ -840,6 +1001,18 @@ async function init() {
 			canvasEl.focus();
 			noteSurfaceFocus("canvas");
 		},
+		onRectSelect: (rect) => {
+			clearAnnotationSelection();
+			if (rect) {
+				const tileCenterMap = new Map(
+					tiles.map((t) => [t.id, { x: t.x + t.width / 2, y: t.y + t.height / 2 }]),
+				);
+				for (const ann of annotations) {
+					if (annotationHitsRect(ann, rect, tileCenterMap)) selectAnnotation(ann.id);
+				}
+			}
+			annotationRenderer?.syncSelectionVisuals();
+		},
 		isShiftHeld: () => shiftHeld,
 		isSpaceHeld: () => spaceHeld,
 		getAllWebviews,
@@ -851,6 +1024,8 @@ async function init() {
 		if (e.key === "Escape" && getSelectedTiles().length > 0) {
 			clearSelection();
 			tileManager.syncSelectionVisuals();
+			clearAnnotationSelection();
+			annotationRenderer?.syncSelectionVisuals();
 			return;
 		}
 
@@ -859,23 +1034,33 @@ async function init() {
 			(activeSurface === "canvas" ||
 				activeSurface === "canvas-tile")
 		) {
-			const selected = getSelectedTiles();
-			if (selected.length === 0) return;
+			const selectedTiles = getSelectedTiles();
+			const selectedAnns = getSelectedAnnotations();
+			if (selectedTiles.length === 0 && selectedAnns.length === 0) return;
 
-			const count = selected.length;
+			const tileCount = selectedTiles.length;
+			const annCount = selectedAnns.length;
+			const parts = [];
+			if (tileCount > 0) parts.push(tileCount === 1 ? "1 tile" : `${tileCount} tiles`);
+			if (annCount > 0) parts.push(annCount === 1 ? "1 annotation" : `${annCount} annotations`);
 			window.shellApi.showConfirmDialog({
-				message: count === 1
-					? "Delete this tile?"
-					: `Delete ${count} tiles?`,
+				message: `Delete ${parts.join(" and ")}?`,
 				detail: "This cannot be undone.",
 				buttons: ["Cancel", "Delete"],
 			}).then((response) => {
 				if (response !== 1) return;
-				for (const t of selected) {
+				for (const t of selectedTiles) {
 					tileManager.closeCanvasTile(t.id);
 				}
 				clearSelection();
 				tileManager.syncSelectionVisuals();
+				for (const ann of selectedAnns) {
+					annotationRenderer?.removeAnnotationDOM(ann.id);
+					removeAnnotation(ann.id);
+				}
+				clearAnnotationSelection();
+				annotationRenderer?.syncSelectionVisuals();
+				tileManager.saveCanvasDebounced();
 				minimap.update();
 			});
 		}
@@ -1559,6 +1744,15 @@ async function init() {
 			: 0;
 		viewport.updateCanvas();
 		tileManager.restoreCanvasState(savedState.tiles);
+		restoreAnnotations(savedState.annotations ?? []);
+		validateAnnotations(
+			new Set(tiles.map((t) => t.id)),
+			(id) => {
+				const t = tiles.find((t2) => t2.id === id);
+				return t ? { x: t.x + t.width / 2, y: t.y + t.height / 2 } : null;
+			},
+		);
+		annotationRenderer.renderAll();
 		viewport.redrawGrid();
 		minimap.update();
 

--- a/collab-electron/src/windows/shell/src/shell.css
+++ b/collab-electron/src/windows/shell/src/shell.css
@@ -17,6 +17,8 @@
 	--edge-dot-hover: rgb(40, 190, 105);
 	--new-tile-btn-bg: rgb(224, 224, 224);
 	--new-tile-btn-bg-hover: rgb(212, 212, 212);
+	--popover-bg: rgb(240, 240, 240);
+	--popover-border: rgba(0, 0, 0, 0.12);
 
 	--panel-nav-min: 100;
 	--panel-nav-max: 1000;
@@ -41,6 +43,8 @@
 	--edge-dot-hover: rgb(90, 235, 150);
 	--new-tile-btn-bg: rgb(44, 44, 44);
 	--new-tile-btn-bg-hover: rgb(56, 56, 56);
+	--popover-bg: rgb(50, 50, 50);
+	--popover-border: rgba(255, 255, 255, 0.12);
 }
 
 * {
@@ -339,7 +343,7 @@ body.platform-win {
 #update-pill {
 	position: absolute;
 	top: 8px;
-	right: 42px;
+	right: 66px;
 	z-index: 101;
 	-webkit-app-region: no-drag;
 	padding: 2px 9px;
@@ -1230,6 +1234,280 @@ body.platform-win {
 
 .dark .tile-url-input:focus {
 	border-color: rgba(255, 255, 255, 0.5);
+}
+
+/* ── Draw button & tool popover ── */
+
+#draw-btn {
+	position: absolute;
+	top: 10px;
+	right: 48px;
+	z-index: 101;
+	-webkit-app-region: no-drag;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--new-tile-btn-bg);
+	color: var(--muted);
+	cursor: pointer;
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+#draw-btn:hover,
+#draw-btn.active {
+	color: var(--fg);
+	background: var(--new-tile-btn-bg-hover);
+}
+
+#draw-btn:active {
+	transform: scale(0.94);
+}
+
+#draw-popover {
+	position: fixed;
+	z-index: 1002;
+	display: flex;
+	flex-direction: row;
+	gap: 2px;
+	padding: 4px;
+	background: var(--popover-bg);
+	border: 1px solid var(--popover-border);
+	border-radius: 8px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+#draw-popover.hidden {
+	display: none;
+}
+
+.draw-tool-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	transition: color 0.15s, background 0.15s;
+}
+
+.draw-tool-btn:hover {
+	color: var(--fg);
+	background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+/* ── Annotation layer ── */
+
+#annotation-layer {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 1;
+	overflow: visible;
+}
+
+#annotation-svg {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	overflow: visible;
+	pointer-events: none;
+}
+
+/* ── Annotation elements ── */
+
+/* .annotation-rect is now an SVG <g> — styles are on the child elements */
+
+.annotation-text {
+	position: absolute;
+	font-family: var(--font-sans);
+	font-weight: 400;
+	pointer-events: auto;
+	cursor: move;
+	user-select: none;
+	white-space: pre;
+	line-height: 1.3;
+}
+
+.annotation-text-editor {
+	position: absolute;
+	font-family: var(--font-sans);
+	font-weight: 400;
+	pointer-events: auto;
+	cursor: text;
+	white-space: pre;
+	line-height: 1.3;
+	min-width: 4px;
+	outline: none;
+	border-bottom: 1px solid currentColor;
+}
+
+/* ── Draw preview ── */
+
+.annotation-preview-rect {
+	position: absolute;
+	border: 2px dashed var(--muted);
+	border-radius: 8px;
+	pointer-events: none;
+	box-sizing: border-box;
+}
+
+/* ── Line target highlight ── */
+
+.annotation-text.annotation-selected {
+	outline: 2px solid #4a9eff !important;
+	outline-offset: 2px;
+}
+
+/* SVG annotation selection — rect and line both use stroke colour */
+g.annotation-selected .ann-rect-visual,
+g.annotation-selected .ann-line-visual {
+	stroke: #4a9eff;
+}
+
+.annotation-line-hover {
+	outline: 2px solid rgba(34, 197, 94, 0.45) !important;
+	outline-offset: 2px;
+}
+
+.annotation-line-source {
+	outline: 2px solid #22c55e !important;
+	outline-offset: 2px;
+}
+
+.annotation-line-target {
+	outline: 2px solid var(--edge-dot) !important;
+	outline-offset: 2px;
+}
+
+/* ── Per-annotation popover ── */
+
+.annotation-popover {
+	position: fixed;
+	z-index: 2000;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 6px;
+	background: var(--popover-bg);
+	border: 1px solid var(--popover-border);
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	font-family: var(--font-sans);
+}
+
+.ann-pop-trash {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: #e5484d;
+	cursor: pointer;
+	transition: background 0.1s;
+}
+
+.ann-pop-trash:hover {
+	background: rgba(229, 72, 77, 0.12);
+}
+
+.ann-pop-color-picker {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	background: none;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.ann-pop-color-picker::-webkit-color-swatch-wrapper {
+	padding: 0;
+}
+
+.ann-pop-color-picker::-webkit-color-swatch {
+	border: none;
+	border-radius: 3px;
+}
+
+.ann-pop-hex-wrap {
+	display: flex;
+	align-items: center;
+	gap: 1px;
+	background: color-mix(in srgb, var(--fg) 6%, transparent);
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	padding: 2px 5px;
+	font-size: 11px;
+	color: var(--muted);
+}
+
+.ann-pop-hex {
+	width: 52px;
+	border: none;
+	background: transparent;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--fg);
+	outline: none;
+}
+
+.ann-pop-font {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	transition: color 0.1s, background 0.1s;
+	font-family: var(--font-sans);
+}
+
+.ann-pop-font:hover {
+	color: var(--fg);
+	background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.ann-pop-font-up {
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.ann-pop-font-down {
+	font-size: 11px;
+}
+
+/* Cursor overrides when draw mode is active */
+#panel-viewer.draw-rect,
+#panel-viewer.draw-line {
+	cursor: crosshair;
+}
+
+#panel-viewer.draw-text {
+	cursor: text;
 }
 
 .tile-url-input::placeholder {

--- a/collab-electron/src/windows/shell/src/tile-interactions.js
+++ b/collab-electron/src/windows/shell/src/tile-interactions.js
@@ -39,6 +39,10 @@ export function attachDrag(titleBar, tile, {
   onFocus,
   isSpaceHeld,
   contentOverlay,
+  isTileInSelection,
+  onGroupDragStart,
+  onGroupDragMove,
+  onGroupDragEnd,
 }) {
   function startDrag(e, { deferFocus = false } = {}) {
     if (e.button !== 0) return;
@@ -56,6 +60,10 @@ export function attachDrag(titleBar, tile, {
 
     const groupCtx = getGroupDragContext();
     const isGroupDrag = groupCtx !== null && groupCtx.length > 1;
+
+    // Fire annotation group drag callbacks if this tile is part of the selection
+    const tileSelected = isTileInSelection?.() ?? false;
+    if (tileSelected) onGroupDragStart?.();
 
     const webviews = getAllWebviews();
     disablePointerEvents(webviews);
@@ -87,6 +95,7 @@ export function attachDrag(titleBar, tile, {
         tile.x = startTX + dx;
         tile.y = startTY + dy;
       }
+      if (tileSelected) onGroupDragMove?.(dx, dy);
       onUpdate();
     }
 
@@ -133,6 +142,7 @@ export function attachDrag(titleBar, tile, {
         snapToGrid(tile);
       }
       onUpdate();
+      if (tileSelected && moved) onGroupDragEnd?.();
     }
 
     document.addEventListener("mousemove", onMove);
@@ -165,8 +175,10 @@ export function attachMarquee(canvasEl, {
   viewport,
   tiles,
   onSelectionChange,
+  onRectSelect,
   isShiftHeld,
   isSpaceHeld,
+  isBlocked,
   getAllWebviews,
 }) {
   const tileLayer = canvasEl.querySelector("#tile-layer");
@@ -174,8 +186,9 @@ export function attachMarquee(canvasEl, {
 
   canvasEl.addEventListener("mousedown", (e) => {
     if (e.button !== 0) return;
-    // Ignore if Space is held (pan gesture)
+    // Ignore if Space is held (pan gesture) or draw mode is active
     if (isSpaceHeld()) return;
+    if (isBlocked?.()) return;
     // Only trigger on clicks directly on the canvas background
     if (
       e.target !== canvasEl &&
@@ -229,6 +242,7 @@ export function attachMarquee(canvasEl, {
       if (!moved) {
         // Click on empty canvas — clear selection
         onSelectionChange(new Set());
+        onRectSelect?.(null);
         return;
       }
 
@@ -265,13 +279,8 @@ export function attachMarquee(canvasEl, {
         }
       }
 
-      if (isShiftHeld()) {
-        // Additive — merge with existing selection handled by caller
-        // Pass the new hits; caller unions with current selection
-        onSelectionChange(hitIds);
-      } else {
-        onSelectionChange(hitIds);
-      }
+      onSelectionChange(hitIds);
+      onRectSelect?.({ left: cTL.x, top: cTL.y, right: cBR.x, bottom: cBR.y });
     }
 
     document.addEventListener("mousemove", onMove);

--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -29,6 +29,11 @@ export function createTileManager({
 	onTileFocused,
 	onTileDblClick,
 	onReposition,
+	onAfterTilesMoved,
+	onTileRemoved,
+	onGroupDragStart,
+	onGroupDragMove,
+	onGroupDragEnd,
 }) {
 	/** @type {Map<string, {container: HTMLElement, contentArea: HTMLElement, titleText: HTMLElement, webview?: HTMLElement}>} */
 	const tileDOMs = new Map();
@@ -102,6 +107,7 @@ export function createTileManager({
 			);
 		}
 		onReposition?.();
+		onAfterTilesMoved?.();
 	}
 
 	// -- Selection visuals --
@@ -548,6 +554,10 @@ export function createTileManager({
 			onFocus: (id, e) => focusCanvasTile(id, e),
 			isSpaceHeld,
 			contentOverlay: dom.contentOverlay,
+			isTileInSelection: () => isSelected(tile.id),
+			onGroupDragStart,
+			onGroupDragMove,
+			onGroupDragEnd,
 		});
 		attachResize(
 			dom.container, tile, viewport,
@@ -592,6 +602,7 @@ export function createTileManager({
 			}
 		}
 		removeTile(id);
+		onTileRemoved?.(id);
 		onReposition?.();
 		saveCanvasImmediate();
 	}


### PR DESCRIPTION
## Why

Working on a large project in Collab often means dozens of terminal and browser tiles scattered across a canvas with no way to communicate structure to yourself have order to the different projects you might run in parralell. There's no way to group related tiles, label what something does, or draw a connection between two terminals that are part of the same pipeline.

This comes up directly in #29 (canvas needs a way to visually group/organise tiles) and #25 (users want to annotate and label their workspace). Right now the only option is careful spatial arrangement, which breaks down fast as a canvas grows.

This PR adds a lightweight annotation layer — rects to group tiles, lines to connect them, and text labels — so you can impose structure on a canvas without changing how tiles themselves work.

## Demo video

https://github.com/user-attachments/assets/d413f438-ee66-4c5b-8c4c-4d6c3e46d7c4

_note since recording the video the location of the draw has moved to near the + like below, and colour of the popovers to match DS_

<img width="150" height="130" alt="image" src="https://github.com/user-attachments/assets/a04f5f84-2b56-46f3-9fc3-5b37fa0790d0" />

<img width="150" height="57" alt="image" src="https://github.com/user-attachments/assets/0b78ce83-7a65-416d-a43f-55ff3daecce5" />

## Changes

| File | What changed |
|---|---|
| `src/windows/shell/src/annotation-manager.ts` | New — pure state module: types, add/remove/update, selection, persist/restore |
| `src/windows/shell/src/annotation-renderer.ts` | New — all SVG/DOM rendering, draw interactions, drag, popover, mode management |
| `src/windows/shell/index.html` | Annotation layer DOM, draw toolbar button + tool popover |
| `src/windows/shell/src/shell.css` | Annotation styles: layers, popovers, tile highlight glows, selection ring |
| `src/windows/shell/src/renderer.js` | Wires annotation renderer into canvas; group drag + delete + restore |
| `src/windows/shell/src/tile-interactions.js` | `onGroupDragStart` / `onGroupDragMove` / `onGroupDragEnd` callbacks for cross-system drag |
| `src/windows/shell/src/tile-manager.js` | Threads group drag callbacks through to `attachDrag` |
| `src/main/canvas-persistence.ts` | Adds `AnnotationState` union type to the persisted canvas schema |

**How it works**

- Annotations render behind the tile layer: SVG `<g>` elements for rects and lines (inside a masked group that hides annotations under tiles), DOM `<div>` elements for text
- All three tools are single-click/drag to create, then revert to pointer mode automatically
- Lines can be *free* (canvas coords) or *connected* (anchored to two tile centers — they track tile movement and only detach when dragged individually)
- Multi-select marquee works across tiles and annotations together; dragging a mixed selection moves everything as a group
- Annotations persist to `canvas-state.json` alongside tiles on every change; `annotations` is optional in the schema so existing state files load cleanly
- Default colour is derived from `--muted` CSS variable so it adapts to light/dark mode

Closes #29, closes #25