### PR TITLE
Add canvas MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ Markdown and code files support inline editing in the viewer. The viewer watches
 
 Pressing Escape closes the viewer (when not actively editing).
 
+### Agent integrations
+
+Collaborator exposes two local integrations for agents:
+
+* `collab-canvas`: a CLI for direct canvas control
+* `collab-canvas-mcp`: a stdio MCP server that exposes canvas tools backed by the same app RPC
+
+The MCP server is intended for agent clients that support local MCP process servers. It exposes tools for:
+
+* listing, creating, moving, resizing, focusing, and removing tiles
+* reading and writing terminal tiles
+* getting and setting the viewport
+
+The installed wrapper commands use the running Collaborator app as their transport, so the app must be open before starting either integration.
+
 ### Persistence
 
 All state is stored locally in `~/.collaborator/`.

--- a/collab-electron/cli/collab-cli.mjs
+++ b/collab-electron/cli/collab-cli.mjs
@@ -1,72 +1,15 @@
 #!/usr/bin/env node
-import { createConnection } from "node:net";
-import { readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { rpcCall } from "./collab-rpc.mjs";
 
 const VERSION = "0.1.0";
 const GRID = 20;
-const COLLAB_DIR = join(homedir(), ".collaborator");
-const SOCKET_FILE = join(COLLAB_DIR, "socket-path");
 
 // --- helpers --------------------------------------------------------------
 
 function die(msg, code = 1) {
   process.stderr.write(`error: ${msg}\n`);
   process.exit(code);
-}
-
-function readSocketPath() {
-  let raw;
-  try {
-    raw = readFileSync(SOCKET_FILE, "utf-8").trim();
-  } catch {
-    die("collaborator is not running (no socket-path file)", 2);
-  }
-  return raw;
-}
-
-function rpcCall(method, params = {}) {
-  return new Promise((res, rej) => {
-    const socketPath = readSocketPath();
-    const payload =
-      JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
-
-    const sock = createConnection(socketPath);
-    let buf = "";
-
-    const timer = setTimeout(() => {
-      sock.destroy();
-      rej(new Error("timeout"));
-    }, 10_000);
-
-    sock.on("connect", () => sock.write(payload));
-
-    sock.on("data", (chunk) => {
-      buf += chunk.toString();
-      const nl = buf.indexOf("\n");
-      if (nl === -1) return;
-      clearTimeout(timer);
-      sock.destroy();
-      let resp;
-      try {
-        resp = JSON.parse(buf.slice(0, nl));
-      } catch {
-        rej(new Error("invalid response from collaborator"));
-        return;
-      }
-      if (resp.error) {
-        rej(new Error(resp.error.message ?? "unknown error"));
-      } else {
-        res(resp.result);
-      }
-    });
-
-    sock.on("error", (err) => {
-      clearTimeout(timer);
-      rej(err);
-    });
-  });
 }
 
 function pretty(obj) {

--- a/collab-electron/cli/collab-mcp-tools.mjs
+++ b/collab-electron/cli/collab-mcp-tools.mjs
@@ -1,0 +1,318 @@
+import * as z from "zod/v4";
+
+export const GRID = 20;
+
+const TILE_TYPE_SCHEMA = z.enum([
+  "term",
+  "note",
+  "code",
+  "image",
+  "graph",
+]);
+
+function pretty(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function toGridPosition(position) {
+  if (!position) return position;
+  return {
+    x: Math.floor(position.x / GRID),
+    y: Math.floor(position.y / GRID),
+  };
+}
+
+function toGridSize(size) {
+  if (!size) return size;
+  return {
+    width: Math.floor(size.width / GRID),
+    height: Math.floor(size.height / GRID),
+  };
+}
+
+export function tilesToGrid(result) {
+  return {
+    ...result,
+    tiles: (result.tiles ?? []).map((tile) => ({
+      ...tile,
+      position: toGridPosition(tile.position),
+      size: toGridSize(tile.size),
+    })),
+  };
+}
+
+export function viewportToGrid(result) {
+  if (!result) return result;
+  return {
+    ...result,
+    pan: toGridPosition(result.pan),
+  };
+}
+
+function toolResult(structuredContent) {
+  return {
+    content: [{ type: "text", text: pretty(structuredContent) }],
+    structuredContent,
+  };
+}
+
+export function createCanvasMcpToolHandlers(rpcCall) {
+  return {
+    async listTiles() {
+      const result = await rpcCall("canvas.tileList");
+      return toolResult(tilesToGrid(result));
+    },
+
+    async createTile({
+      type,
+      filePath,
+      x,
+      y,
+      width,
+      height,
+    }) {
+      const params = { tileType: type };
+      if (filePath) params.filePath = filePath;
+      if (x !== undefined || y !== undefined) {
+        if (x === undefined || y === undefined) {
+          throw new Error("x and y must be provided together");
+        }
+        params.position = { x: x * GRID, y: y * GRID };
+      }
+      if (width !== undefined || height !== undefined) {
+        if (width === undefined || height === undefined) {
+          throw new Error("width and height must be provided together");
+        }
+        params.size = { width: width * GRID, height: height * GRID };
+      }
+
+      const result = await rpcCall("canvas.tileCreate", params);
+      return toolResult(result);
+    },
+
+    async removeTile({ tileId }) {
+      await rpcCall("canvas.tileRemove", { tileId });
+      return toolResult({ ok: true, tileId });
+    },
+
+    async moveTile({ tileId, x, y }) {
+      await rpcCall("canvas.tileMove", {
+        tileId,
+        position: { x: x * GRID, y: y * GRID },
+      });
+      return toolResult({ ok: true, tileId, position: { x, y } });
+    },
+
+    async resizeTile({ tileId, width, height }) {
+      await rpcCall("canvas.tileResize", {
+        tileId,
+        size: { width: width * GRID, height: height * GRID },
+      });
+      return toolResult({
+        ok: true,
+        tileId,
+        size: { width, height },
+      });
+    },
+
+    async focusTiles({ tileIds }) {
+      await rpcCall("canvas.tileFocus", { tileIds });
+      return toolResult({ ok: true, tileIds });
+    },
+
+    async getViewport() {
+      const result = await rpcCall("canvas.viewportGet");
+      return toolResult(viewportToGrid(result));
+    },
+
+    async setViewport({ x, y, zoom }) {
+      const params = {};
+      if (x !== undefined || y !== undefined) {
+        if (x === undefined || y === undefined) {
+          throw new Error("x and y must be provided together");
+        }
+        params.pan = { x: x * GRID, y: y * GRID };
+      }
+      if (zoom !== undefined) {
+        params.zoom = zoom;
+      }
+
+      await rpcCall("canvas.viewportSet", params);
+      return toolResult({
+        ok: true,
+        ...(params.pan ? { pan: { x, y } } : {}),
+        ...(zoom !== undefined ? { zoom } : {}),
+      });
+    },
+
+    async writeTerminal({ tileId, input }) {
+      await rpcCall("canvas.terminalWrite", { tileId, input });
+      return toolResult({ ok: true, tileId });
+    },
+
+    async readTerminal({ tileId, lines = 50 }) {
+      const result = await rpcCall("canvas.terminalRead", {
+        tileId,
+        lines,
+      });
+      return toolResult(result);
+    },
+  };
+}
+
+export function registerCanvasMcpTools(server, rpcCall) {
+  const handlers = createCanvasMcpToolHandlers(rpcCall);
+
+  server.registerTool("canvas_list_tiles", {
+    title: "List Canvas Tiles",
+    description: "List all canvas tiles in grid units.",
+    outputSchema: {
+      tiles: z.array(z.object({
+        id: z.string(),
+        type: z.string(),
+        filePath: z.string().optional(),
+        folderPath: z.string().optional(),
+        position: z.object({
+          x: z.number(),
+          y: z.number(),
+        }).optional(),
+        size: z.object({
+          width: z.number(),
+          height: z.number(),
+        }).optional(),
+      })),
+    },
+  }, handlers.listTiles);
+
+  server.registerTool("canvas_create_tile", {
+    title: "Create Canvas Tile",
+    description:
+      "Create a canvas tile. Coordinates and sizes are in grid units.",
+    inputSchema: {
+      type: TILE_TYPE_SCHEMA,
+      filePath: z.string().optional(),
+      x: z.number().int().min(0).optional(),
+      y: z.number().int().min(0).optional(),
+      width: z.number().int().positive().optional(),
+      height: z.number().int().positive().optional(),
+    },
+    outputSchema: {
+      tileId: z.string(),
+    },
+  }, handlers.createTile);
+
+  server.registerTool("canvas_remove_tile", {
+    title: "Remove Canvas Tile",
+    description: "Remove a tile from the canvas.",
+    inputSchema: {
+      tileId: z.string(),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      tileId: z.string(),
+    },
+  }, handlers.removeTile);
+
+  server.registerTool("canvas_move_tile", {
+    title: "Move Canvas Tile",
+    description: "Move a tile to a new grid position.",
+    inputSchema: {
+      tileId: z.string(),
+      x: z.number().int().min(0),
+      y: z.number().int().min(0),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      tileId: z.string(),
+      position: z.object({
+        x: z.number(),
+        y: z.number(),
+      }),
+    },
+  }, handlers.moveTile);
+
+  server.registerTool("canvas_resize_tile", {
+    title: "Resize Canvas Tile",
+    description: "Resize a tile using grid units.",
+    inputSchema: {
+      tileId: z.string(),
+      width: z.number().int().positive(),
+      height: z.number().int().positive(),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      tileId: z.string(),
+      size: z.object({
+        width: z.number(),
+        height: z.number(),
+      }),
+    },
+  }, handlers.resizeTile);
+
+  server.registerTool("canvas_focus_tiles", {
+    title: "Focus Canvas Tiles",
+    description: "Pan and zoom the viewport to bring tiles into view.",
+    inputSchema: {
+      tileIds: z.array(z.string()).min(1),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      tileIds: z.array(z.string()),
+    },
+  }, handlers.focusTiles);
+
+  server.registerTool("canvas_get_viewport", {
+    title: "Get Canvas Viewport",
+    description: "Get the current viewport pan and zoom in grid units.",
+    outputSchema: {
+      pan: z.object({
+        x: z.number(),
+        y: z.number(),
+      }),
+      zoom: z.number(),
+    },
+  }, handlers.getViewport);
+
+  server.registerTool("canvas_set_viewport", {
+    title: "Set Canvas Viewport",
+    description: "Set viewport pan in grid units and/or zoom.",
+    inputSchema: {
+      x: z.number().int().min(0).optional(),
+      y: z.number().int().min(0).optional(),
+      zoom: z.number().positive().optional(),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      pan: z.object({
+        x: z.number(),
+        y: z.number(),
+      }).optional(),
+      zoom: z.number().optional(),
+    },
+  }, handlers.setViewport);
+
+  server.registerTool("canvas_write_terminal", {
+    title: "Write To Canvas Terminal",
+    description: "Send input to a terminal tile.",
+    inputSchema: {
+      tileId: z.string(),
+      input: z.string(),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      tileId: z.string(),
+    },
+  }, handlers.writeTerminal);
+
+  server.registerTool("canvas_read_terminal", {
+    title: "Read Canvas Terminal",
+    description: "Read recent output from a terminal tile.",
+    inputSchema: {
+      tileId: z.string(),
+      lines: z.number().int().positive().optional(),
+    },
+    outputSchema: {
+      output: z.string(),
+    },
+  }, handlers.readTerminal);
+}

--- a/collab-electron/cli/collab-mcp-tools.test.ts
+++ b/collab-electron/cli/collab-mcp-tools.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createCanvasMcpToolHandlers,
+  tilesToGrid,
+  viewportToGrid,
+} from "./collab-mcp-tools.mjs";
+
+describe("collab-mcp-tools", () => {
+  test("tilesToGrid converts pixel coordinates to grid units", () => {
+    expect(tilesToGrid({
+      tiles: [{
+        id: "tile-1",
+        type: "note",
+        position: { x: 40, y: 60 },
+        size: { width: 220, height: 540 },
+      }],
+    })).toEqual({
+      tiles: [{
+        id: "tile-1",
+        type: "note",
+        position: { x: 2, y: 3 },
+        size: { width: 11, height: 27 },
+      }],
+    });
+  });
+
+  test("viewportToGrid converts pan to grid units", () => {
+    expect(viewportToGrid({
+      pan: { x: 100, y: 220 },
+      zoom: 0.8,
+    })).toEqual({
+      pan: { x: 5, y: 11 },
+      zoom: 0.8,
+    });
+  });
+
+  test("createTile maps grid input to canvas.tileCreate params", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const handlers = createCanvasMcpToolHandlers(async (method, params) => {
+      calls.push({ method, params });
+      return { tileId: "tile-123" };
+    });
+
+    const result = await handlers.createTile({
+      type: "code",
+      filePath: "/tmp/file.ts",
+      x: 5,
+      y: 6,
+      width: 22,
+      height: 27,
+    });
+
+    expect(calls).toEqual([{
+      method: "canvas.tileCreate",
+      params: {
+        tileType: "code",
+        filePath: "/tmp/file.ts",
+        position: { x: 100, y: 120 },
+        size: { width: 440, height: 540 },
+      },
+    }]);
+    expect(result.structuredContent).toEqual({ tileId: "tile-123" });
+  });
+
+  test("setViewport maps grid pan to pixel pan", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const handlers = createCanvasMcpToolHandlers(async (method, params) => {
+      calls.push({ method, params });
+      return {};
+    });
+
+    const result = await handlers.setViewport({ x: 3, y: 4, zoom: 0.75 });
+
+    expect(calls).toEqual([{
+      method: "canvas.viewportSet",
+      params: {
+        pan: { x: 60, y: 80 },
+        zoom: 0.75,
+      },
+    }]);
+    expect(result.structuredContent).toEqual({
+      ok: true,
+      pan: { x: 3, y: 4 },
+      zoom: 0.75,
+    });
+  });
+
+  test("readTerminal defaults lines to 50", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const handlers = createCanvasMcpToolHandlers(async (method, params) => {
+      calls.push({ method, params });
+      return { output: "ok" };
+    });
+
+    const result = await handlers.readTerminal({ tileId: "tile-1" });
+
+    expect(calls).toEqual([{
+      method: "canvas.terminalRead",
+      params: { tileId: "tile-1", lines: 50 },
+    }]);
+    expect(result.structuredContent).toEqual({ output: "ok" });
+  });
+});

--- a/collab-electron/cli/collab-mcp.mjs
+++ b/collab-electron/cli/collab-mcp.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerCanvasMcpTools } from "./collab-mcp-tools.mjs";
+import { rpcCall } from "./collab-rpc.mjs";
+
+async function main() {
+  const server = new McpServer({
+    name: "collaborator-canvas",
+    version: "0.1.0",
+  });
+
+  registerCanvasMcpTools(server, rpcCall);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("collab-canvas-mcp error:", error);
+  process.exit(1);
+});

--- a/collab-electron/cli/collab-rpc.mjs
+++ b/collab-electron/cli/collab-rpc.mjs
@@ -1,0 +1,86 @@
+import { createConnection } from "node:net";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const COLLAB_DIR = join(homedir(), ".collaborator");
+const SOCKET_FILE = join(COLLAB_DIR, "socket-path");
+
+export function readSocketPath() {
+  try {
+    return readFileSync(SOCKET_FILE, "utf-8").trim();
+  } catch {
+    const err = new Error(
+      "collaborator is not running (no socket-path file)",
+    );
+    err.exitCode = 2;
+    throw err;
+  }
+}
+
+export function rpcCall(method, params = {}) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    function fail(error) {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    }
+
+    function succeed(result) {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    }
+
+    let socketPath;
+    try {
+      socketPath = readSocketPath();
+    } catch (error) {
+      fail(error);
+      return;
+    }
+
+    const payload =
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
+
+    const sock = createConnection(socketPath);
+    let buf = "";
+
+    const timer = setTimeout(() => {
+      sock.destroy();
+      fail(new Error("timeout"));
+    }, 10_000);
+
+    sock.on("connect", () => sock.write(payload));
+
+    sock.on("data", (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+
+      clearTimeout(timer);
+      sock.destroy();
+
+      let resp;
+      try {
+        resp = JSON.parse(buf.slice(0, nl));
+      } catch {
+        fail(new Error("invalid response from collaborator"));
+        return;
+      }
+
+      if (resp.error) {
+        fail(new Error(resp.error.message ?? "unknown error"));
+      } else {
+        succeed(resp.result);
+      }
+    });
+
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      fail(err);
+    });
+  });
+}

--- a/collab-electron/package.json
+++ b/collab-electron/package.json
@@ -73,6 +73,10 @@
 				"to": "collab-cli.mjs"
 			},
 			{
+				"from": "cli/collab-mcp.mjs",
+				"to": "collab-mcp.mjs"
+			},
+			{
 				"from": "packages/collab-canvas-skill",
 				"to": "collab-canvas-skill"
 			}
@@ -125,6 +129,7 @@
 		"@blocknote/react": "0.47.0",
 		"@lezer/common": "^1.5.1",
 		"@lezer/python": "^1.1.18",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@parcel/watcher": "2.5.6",
 		"@phosphor-icons/react": "2.1.7",
 		"@posthog/react": "^1.8.2",
@@ -159,7 +164,8 @@
 		"streamdown": "2.3.0",
 		"tailwind-merge": "3.5.0",
 		"typescript": "5.9.3",
-		"use-stick-to-bottom": "1.1.3"
+		"use-stick-to-bottom": "1.1.3",
+		"zod": "^4.3.6"
 	},
 	"overrides": {
 		"@tiptap/core": "3.20.0",

--- a/collab-electron/src/main/cli-installer.ts
+++ b/collab-electron/src/main/cli-installer.ts
@@ -21,15 +21,20 @@ const INSTALL_DIR = IS_WIN
   : join(homedir(), ".local", "bin");
 const WRAPPER_PATH = join(INSTALL_DIR, IS_WIN ? "collab-canvas.cmd" : "collab-canvas");
 const MJS_PATH = join(INSTALL_DIR, "collab-cli.mjs");
+const MCP_WRAPPER_PATH = join(
+  INSTALL_DIR,
+  IS_WIN ? "collab-canvas-mcp.cmd" : "collab-canvas-mcp",
+);
+const MCP_MJS_PATH = join(INSTALL_DIR, "collab-mcp.mjs");
 
-function getMjsSource(): string {
+function getCliSource(filename: string): string {
   if (app.isPackaged) {
-    return join(process.resourcesPath, "collab-cli.mjs");
+    return join(process.resourcesPath, filename);
   }
-  return join(app.getAppPath(), "cli", "collab-cli.mjs");
+  return join(app.getAppPath(), "cli", filename);
 }
 
-function generateUnixWrapper(): string {
+function generateUnixWrapper(scriptName: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 NODE_BIN="$(cat "$HOME/.collaborator/node-path" 2>/dev/null)" || true
@@ -37,11 +42,11 @@ if [[ -z "$NODE_BIN" || ! -x "$NODE_BIN" ]]; then
   echo "error: collaborator is not running (no node-path file)" >&2
   exit 2
 fi
-ELECTRON_RUN_AS_NODE=1 exec "$NODE_BIN" "$(dirname "$0")/collab-cli.mjs" "$@"
+ELECTRON_RUN_AS_NODE=1 exec "$NODE_BIN" "$(dirname "$0")/${scriptName}" "$@"
 `;
 }
 
-function generateWindowsWrapper(): string {
+function generateWindowsWrapper(scriptName: string): string {
   return `@echo off
 setlocal
 set "NP_FILE=%USERPROFILE%\\.collaborator\\node-path"
@@ -51,14 +56,18 @@ if not exist "%NP_FILE%" (
 )
 set /p NODE_BIN=<"%NP_FILE%"
 set ELECTRON_RUN_AS_NODE=1
-"%NODE_BIN%" "%~dp0collab-cli.mjs" %*
+"%NODE_BIN%" "%~dp0${scriptName}" %*
 `;
 }
 
 export function installCli(): void {
-  const mjsSource = getMjsSource();
-  if (!existsSync(mjsSource)) {
-    console.warn("[cli-installer] CLI source not found:", mjsSource);
+  const cliSource = getCliSource("collab-cli.mjs");
+  const mcpSource = getCliSource("collab-mcp.mjs");
+  if (!existsSync(cliSource) || !existsSync(mcpSource)) {
+    console.warn(
+      "[cli-installer] CLI source not found:",
+      !existsSync(cliSource) ? cliSource : mcpSource,
+    );
     return;
   }
 
@@ -75,12 +84,22 @@ export function installCli(): void {
 
   mkdirSync(INSTALL_DIR, { recursive: true });
 
-  copyFileSync(mjsSource, MJS_PATH);
+  copyFileSync(cliSource, MJS_PATH);
+  copyFileSync(mcpSource, MCP_MJS_PATH);
 
-  const wrapper = IS_WIN ? generateWindowsWrapper() : generateUnixWrapper();
+  const wrapper = IS_WIN
+    ? generateWindowsWrapper("collab-cli.mjs")
+    : generateUnixWrapper("collab-cli.mjs");
   writeFileSync(WRAPPER_PATH, wrapper, "utf-8");
+
+  const mcpWrapper = IS_WIN
+    ? generateWindowsWrapper("collab-mcp.mjs")
+    : generateUnixWrapper("collab-mcp.mjs");
+  writeFileSync(MCP_WRAPPER_PATH, mcpWrapper, "utf-8");
+
   if (!IS_WIN) {
     chmodSync(WRAPPER_PATH, 0o755);
+    chmodSync(MCP_WRAPPER_PATH, 0o755);
   }
 
   if (IS_WIN) {


### PR DESCRIPTION
## What changed

This adds a local stdio MCP server for Collaborator's canvas on top of the existing app JSON-RPC transport.

The change introduces:
- a new `collab-canvas-mcp` server entrypoint
- MCP tools for listing, creating, moving, resizing, focusing, and removing tiles
- MCP tools for reading and writing terminal tiles
- viewport get/set tools
- shared RPC helper reuse between the CLI and MCP server
- installer and packaging support for the new MCP wrapper
- focused tests for the MCP handler layer

## Why

The repo already had canvas operations exposed through an internal JSON-RPC server and the `collab-canvas` CLI, but not through MCP.

Adding MCP makes the integration explicit and tool-native for clients like Codex instead of relying on shell instructions and PATH discovery.

## Impact

Agent clients that support local stdio MCP servers can now connect to Collaborator's canvas through a typed tool surface.

The existing `collab-canvas` CLI remains available and now shares the same RPC helper logic.

## Validation

- `bun test cli/collab-mcp-tools.test.ts`
- `bunx tsc --noEmit -p tsconfig.json`
- manual MCP smoke test from Codex against the live Windows Collaborator session (`tools/list` + `canvas_list_tiles`)
