### PR TITLE
fix: fall back to home dir when terminal cwd does not exist

### DIFF
--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -185,7 +185,7 @@ interface ShortcutEntry {
 const TOGGLE_SHORTCUTS: Record<string, ShortcutEntry[]> = {
   KeyB: [
     { modifier: altCmdOrCtrl, action: "toggle-agent" },
-    { modifier: cmdOrCtrl, action: "sidebar-files" },
+    { modifier: shiftCmdOrCtrl, action: "sidebar-files" },
   ],
   Backslash: [{ modifier: cmdOrCtrl, action: "sidebar-files" }],
   Comma: [{ modifier: cmdOrCtrl, action: "toggle-settings" }],
@@ -377,7 +377,7 @@ function buildAppMenu(): void {
       submenu: [
         {
           label: "Toggle Files",
-          accelerator: "CommandOrControl+B",
+          accelerator: "CommandOrControl+Shift+B",
           registerAccelerator: false,
           click: () => sendShortcut("sidebar-files"),
         },

--- a/collab-electron/src/main/pty.ts
+++ b/collab-electron/src/main/pty.ts
@@ -485,7 +485,14 @@ export async function createSession(
   cwdHostPath: string;
   cwdGuestPath?: string;
 }> {
-  const resolvedCwd = cwd || os.homedir();
+  let resolvedCwd = cwd || os.homedir();
+  // Fall back to home directory if the requested cwd does not exist
+  // (e.g. a remembered remote/WSL path on a local macOS host).
+  try {
+    fs.accessSync(resolvedCwd);
+  } catch {
+    resolvedCwd = os.homedir();
+  }
   const shell = process.env.SHELL || "/bin/zsh";
   const c = cols || 80;
   const r = rows || 24;

--- a/collab-electron/src/windows/shell/index.html
+++ b/collab-electron/src/windows/shell/index.html
@@ -15,7 +15,7 @@
 			id="alpha-dismiss" href="#">[<span>DISMISS</span>]</a></span>
 
 	<button type="button" id="nav-toggle" class="panel-toggle" aria-pressed="true" aria-label="Hide Navigator"
-		data-tooltip="Toggle Nav" data-shortcut="Cmd+B"></button>
+		data-tooltip="Toggle Nav" data-shortcut="Shift+Cmd+B"></button>
 
 	<button type="button" id="agent-toggle" class="panel-toggle" aria-pressed="false" aria-label="Show Agent"
 		data-tooltip="Toggle Agent" data-shortcut="Opt+Cmd+B"></button>


### PR DESCRIPTION
## Summary
- **Terminal tile crash fix**: When a terminal tile remembers a remote/WSL cwd (e.g. `/home/user/`) that does not exist on the local macOS host, the spawned shell exits immediately, causing the tile to flash and disappear. Added `fs.accessSync` validation before spawning — falls back to `os.homedir()` when the path is inaccessible.
- **Sidebar shortcut change**: Changed the sidebar-files toggle from `Cmd+B` to `Cmd+Shift+B` to avoid conflicts with common terminal keybindings (e.g. tmux prefix). Updated menu accelerator and tooltip to match. `Cmd+\` remains as an alternative.

## Test plan
- [ ] Create two terminal tiles, one with a remote/WSL target so its cwd is a non-local path (e.g. `/home/user/`)
- [ ] Close and reopen the app so the cwd is remembered
- [ ] Create a third terminal tile — it should open in the home directory instead of crashing
- [ ] Verify `Cmd+Shift+B` toggles the sidebar
- [ ] Verify `Cmd+\` still toggles the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)