### PR TITLE
Fix #126: stop note tiles from triggering ENOENT on undefined file path

### DIFF
--- a/collab-electron/src/windows/shell/src/tile-manager.js
+++ b/collab-electron/src/windows/shell/src/tile-manager.js
@@ -622,9 +622,14 @@ export function createTileManager({
 			const wv = document.createElement("webview");
 			const viewerConfig = configs.viewer;
 			const mode = type === "note" ? "note" : "code";
+			const viewerParams = new URLSearchParams();
+			if (typeof filePath === "string" && filePath.length > 0) {
+				viewerParams.set("tilePath", filePath);
+			}
+			viewerParams.set("tileMode", mode);
 			wv.setAttribute(
 				"src",
-				`${viewerConfig.src}?tilePath=${encodeURIComponent(filePath)}&tileMode=${mode}`,
+				`${viewerConfig.src}?${viewerParams.toString()}`,
 			);
 			wv.setAttribute("preload", viewerConfig.preload);
 			wv.setAttribute(

--- a/collab-electron/src/windows/viewer/src/App.tsx
+++ b/collab-electron/src/windows/viewer/src/App.tsx
@@ -108,7 +108,7 @@ export default function App() {
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
 		const tp = params.get("tilePath");
-		if (tp) {
+		if (tp && tp !== "undefined" && tp !== "null") {
 			setSelectedPath(tp);
 		}
 	}, []);


### PR DESCRIPTION
Fixes #126.

## Root cause

Tracing the ENOENT from the issue:

1. `canvas-rpc.js:104` — RPC `tileCreate` defaults `tileType` to `"note"`. For a note with no backing file, it falls through to `createFileTile("note", x, y, undefined)`.
2. `tile-manager.js:626-628` — Builds the viewer webview URL with `\`tilePath=\${encodeURIComponent(filePath)}\``. `encodeURIComponent(undefined)` returns the literal string `"undefined"`, so the URL becomes `viewer.html?tilePath=undefined&tileMode=note`.
3. `viewer/src/App.tsx:108-114` — Parses `tilePath` from the URL. `params.get("tilePath")` returns the **string** `"undefined"`. The `if (tp)` guard treats it as truthy and calls `setSelectedPath("undefined")`.
4. `viewer/src/App.tsx:324` — Subsequently calls `window.api.readFile("undefined")`. The desktop bridge resolves the relative path against the app install dir, producing the path from the issue:

   ```
   ENOENT: no such file or directory, open 'C:\Users\…\AppData\Local\Programs\Collaborator\undefined'
   ```

## Fix

Two surgical changes, both upstream of the IPC call:

### `collab-electron/src/windows/shell/src/tile-manager.js`

Build the viewer URL with `URLSearchParams` and only set `tilePath` when `filePath` is a non-empty string. Note tiles without a backing file now get a viewer URL with no `tilePath` at all, so the viewer's existing `if (!selectedPath) return;` guard catches them naturally and never calls `readFile`.

### `collab-electron/src/windows/viewer/src/App.tsx`

Defense in depth — treat the literal strings `"undefined"` and `"null"` as missing `tilePath`. This protects against any other caller that might still emit a stringified nullish value (e.g. older serialized state, third-party RPC callers).

## What this does *not* do

This PR fixes the crash but does not implement in-memory note content. Note tiles created without a backing file will render an empty viewer rather than throwing. The viewer already accepts a `tileMode` query param but does not currently branch on it — adding real in-memory note rendering is a larger scope and belongs in a follow-up.

## Verification

Repro from the issue:
1. Create a note tile via the canvas tools.
2. Before this PR: ENOENT error in the main process log, viewer fails to render.
3. After this PR: viewer renders an empty tile, no error in the log.
