### PR TITLE
feat(settings): configurable shell command for new terminals

### DIFF
--- a/collab-electron/src/main/config.ts
+++ b/collab-electron/src/main/config.ts
@@ -127,3 +127,11 @@ export function getTerminalTarget(): TerminalTarget {
   const target = getPref(config, "terminalTarget");
   return isTerminalTarget(target) ? target : "auto";
 }
+
+export function getTerminalCommand(): string | null {
+  const config = loadConfig();
+  const value = getPref(config, "terminalCommand");
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/collab-electron/src/main/index.ts
+++ b/collab-electron/src/main/index.ts
@@ -48,7 +48,7 @@ import {
 } from "./analytics";
 import { stopImageWorker } from "./image-service";
 import { installCli } from "./cli-installer";
-import { listTerminalTargets } from "./terminal-target";
+import { commandExists, listTerminalTargets } from "./terminal-target";
 import { readSessionMeta } from "./tmux";
 import { registerBrowserIpc } from "./ipc-browser";
 import { registerAgentIpc } from "./acp-agent";
@@ -566,6 +566,15 @@ ipcMain.handle(
 ipcMain.handle(
   "terminal:list-targets",
   () => listTerminalTargets(),
+);
+
+ipcMain.handle(
+  "terminal:check-shell-command",
+  (_event, command: string) => {
+    const trimmed = typeof command === "string" ? command.trim() : "";
+    if (trimmed === "") return true;
+    return commandExists(trimmed);
+  },
 );
 
 ipcMain.handle(

--- a/collab-electron/src/main/pty.ts
+++ b/collab-electron/src/main/pty.ts
@@ -32,7 +32,7 @@ import {
   SIDECAR_PID_PATH,
 } from "./sidecar/protocol";
 import { COLLAB_DIR } from "./paths";
-import { resolveTerminalTarget } from "./terminal-target";
+import { resolveShellPath, resolveTerminalTarget } from "./terminal-target";
 
 interface PtySession {
   pty: pty.IPty;
@@ -486,7 +486,7 @@ export async function createSession(
   cwdGuestPath?: string;
 }> {
   const resolvedCwd = cwd || os.homedir();
-  const shell = process.env.SHELL || "/bin/zsh";
+  const shell = resolveShellPath();
   const c = cols || 80;
   const r = rows || 24;
 
@@ -520,6 +520,7 @@ export async function createSession(
       "-c", resolvedCwd,
       "-x", String(c),
       "-y", String(r),
+      shell,
     );
 
     if (zshIntegrated) {

--- a/collab-electron/src/main/terminal-target.ts
+++ b/collab-electron/src/main/terminal-target.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import * as os from "node:os";
 import { displayBasename, hostPathToGuestPath, parseWslUncPath } from "@collab/shared/path-utils";
-import { type TerminalTarget } from "./config";
+import { getTerminalCommand, type TerminalTarget } from "./config";
 
 export interface TerminalTargetOption {
   id: TerminalTarget;
@@ -33,7 +33,7 @@ interface WslDistro {
   isDefault: boolean;
 }
 
-function commandExists(command: string): boolean {
+export function commandExists(command: string): boolean {
   try {
     execFileSync(
       process.platform === "win32" ? "where.exe" : "which",
@@ -121,7 +121,9 @@ function resolveWindowsAutoTarget(
   return defaultDistro ? `wsl:${defaultDistro}` : "powershell";
 }
 
-function resolveShellPath(): string {
+export function resolveShellPath(): string {
+  const override = getTerminalCommand();
+  if (override && commandExists(override)) return override;
   if (process.platform === "darwin") {
     return process.env.SHELL || "/bin/zsh";
   }

--- a/collab-electron/src/preload/universal.ts
+++ b/collab-electron/src/preload/universal.ts
@@ -156,6 +156,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("pref:set", key, value),
   listTerminalTargets: () =>
     ipcRenderer.invoke("terminal:list-targets"),
+  checkShellCommand: (command: string) =>
+    ipcRenderer.invoke("terminal:check-shell-command", command),
   getWorkspacePref: (key: string, workspacePath: string) =>
     ipcRenderer.invoke("workspace-pref:get", { key, workspacePath }),
   setWorkspacePref: (key: string, value: unknown, workspacePath: string) =>

--- a/collab-electron/src/windows/settings/src/App.tsx
+++ b/collab-electron/src/windows/settings/src/App.tsx
@@ -20,6 +20,7 @@ interface SettingsApi {
     label: string;
     isDefault?: boolean;
   }>>;
+  checkShellCommand: (command: string) => Promise<boolean>;
   setTheme: (mode: string) => Promise<void>;
   getAppVersion: () => Promise<string>;
   getAgents: () => Promise<AgentStatus[]>;
@@ -386,6 +387,90 @@ function RadioOption({
   );
 }
 
+function ShellCommandField() {
+  const [value, setValue] = useState("");
+  const [loaded, setLoaded] = useState(false);
+  const [status, setStatus] = useState<"ok" | "missing" | null>(null);
+
+  const validate = useCallback(async (command: string) => {
+    const trimmed = command.trim();
+    if (trimmed === "") {
+      setStatus(null);
+      return;
+    }
+    try {
+      const exists = await api.checkShellCommand(trimmed);
+      setStatus(exists ? "ok" : "missing");
+    } catch {
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    api.getPref("terminalCommand")
+      .then((v) => {
+        if (typeof v === "string") {
+          setValue(v);
+          void validate(v);
+        }
+      })
+      .catch(() => { })
+      .finally(() => setLoaded(true));
+  }, [validate]);
+
+  async function commit() {
+    const trimmed = value.trim();
+    await api.setPref("terminalCommand", trimmed);
+    await validate(trimmed);
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Shell command</p>
+      <input
+        type="text"
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        disabled={!loaded}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          setStatus(null);
+        }}
+        onBlur={() => { void commit(); }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        placeholder="Default (login shell)"
+        className="w-full rounded-md px-3 py-2 text-sm font-mono focus:outline-none"
+        style={{
+          backgroundColor:
+            "color-mix(in srgb, var(--foreground) 6%, transparent)",
+          border: `1px solid ${status === "missing"
+            ? "#ef4444"
+            : "color-mix(in srgb, var(--foreground) 15%, transparent)"}`,
+          color: "var(--foreground)",
+        }}
+      />
+      {status === "missing" ? (
+        <p className="text-xs" style={{ color: "#ef4444" }}>
+          Not found on PATH. New terminals will fall back to your login shell.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Name or path of a shell binary (e.g.
+          {" "}
+          <span className="font-mono">/bin/bash</span>
+          ). Leave empty to use your login shell.
+        </p>
+      )}
+    </div>
+  );
+}
+
 function MacTerminalPane() {
   const [mode, setMode] = useState<TerminalMode>("sidecar");
 
@@ -410,6 +495,8 @@ function MacTerminalPane() {
           Changes take effect for new terminals.
         </p>
       </div>
+
+      <ShellCommandField />
 
       <div className="space-y-2">
         <p className="text-sm font-medium">Terminal backend</p>


### PR DESCRIPTION
  ## Summary                                             

  Adds a "Shell command" field in **Settings → Terminal** that overrides the binary launched for new terminal sessions. Useful for users who  want Collaborator to spawn `fish`, `nushell`, a non-default `bash`, etc. without changing their system login shell.
                                                                                                                                              
  Empty value falls back to `$SHELL` (existing behavior), so this is purely additive — no effect for users who don't opt in.                  
  
  ## Changes                                                                                                                                  
                                                         
  - New `ui.terminalCommand` pref (string; empty/unset = default).                                                                            
  - `resolveShellPath()` in `terminal-target.ts` centralizes the lookup: config override (if it resolves on `PATH`) → `$SHELL` → platform
  default. If the configured binary isn't found, new terminals silently fall back instead of spawning-and-failing.                            
  - Both PTY paths consume it:                           
    - **Sidecar** via the existing `resolveTerminalTarget()` call.                                                                            
    - **tmux** by passing the resolved shell as the trailing arg to `tmux new-session` (previously tmux fell back to its `default-shell`,     
  ignoring the config).                                                                                                                       
  - Settings UI: text input above the backend radio. Commits on blur / Enter. Accepts a name on `PATH` (e.g. `fish`) or an absolute path (e.g.
   `/bin/bash`). Live-validates against `which`; a missing binary shows a red outline + inline hint so the fallback behavior is never         
  surprising.                                            
  - New IPC `terminal:check-shell-command` backing the validation.                                                                            
                                                                                                                                              
  ## Test plan
                                                                                                                                              
  - [ ] Leave the field empty → new terminals spawn `$SHELL` as before.                                                                       
  - [ ] Set to `fish` (on `PATH`) → new terminals spawn fish. Tile title shows `fish`.
  - [ ] Set to `/bin/bash` → new terminals spawn bash.                                                                                        
  - [ ] Set to `/nope/does-not-exist` → input shows red "Not found on PATH" hint; new terminals fall back to default (no open-then-close).
  - [ ] Toggle backend between **node-pty** and **tmux** and verify the override applies in both.  